### PR TITLE
[sim] make logging optional

### DIFF
--- a/simulator/src/config.rs
+++ b/simulator/src/config.rs
@@ -29,6 +29,9 @@ pub struct Config {
     /// Simulation configuration including timing, retry settings, and execution parameters
     #[serde(default)]
     pub simulation_config: SimulationConfig,
+    /// Logging configuration for controlling output verbosity
+    #[serde(default)]
+    pub logging_config: LoggingConfig,
 }
 
 /// Configuration for network-related simulation parameters.
@@ -75,6 +78,30 @@ pub struct TransactionConfig {
     pub cat_lifetime_blocks: u64,
     /// Whether CATs can depend on locked keys from pending transactions (affects transaction ordering)
     pub allow_cat_pending_dependencies: bool,
+}
+
+/// Configuration for logging and output control.
+/// 
+/// This struct defines parameters that control the verbosity and output
+/// of the simulation, including log levels and output destinations.
+#[derive(Debug, Deserialize, Clone)]
+pub struct LoggingConfig {
+    /// Whether to log to file (true = write to file, false = no logging)
+    #[serde(default = "default_log_to_file")]
+    pub log_to_file: bool,
+}
+
+/// Default value for log to file
+fn default_log_to_file() -> bool {
+    false
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            log_to_file: false,
+        }
+    }
 }
 
 /// Configuration for simulation execution parameters.

--- a/simulator/src/scenarios/sim_simple/config.toml
+++ b/simulator/src/scenarios/sim_simple/config.toml
@@ -55,4 +55,9 @@ max_retries = 100
 num_runs = 20
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
-sim_total_block_number = 1000
+sim_total_block_number = 50
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/config.toml
@@ -61,3 +61,8 @@ block_count = 50
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 1000
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/simulation.rs
@@ -95,6 +95,7 @@ pub async fn run_sweep_block_interval_constant_block_delay() -> Result<(), crate
                     account_config: base_config.account_config.clone(),
                     transaction_config: base_config.transaction_config.clone(),
                     simulation_config: base_config.simulation_config.clone(),
+                    logging_config: base_config.logging_config.clone(),
                 }
             })
         }),

--- a/simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/config.toml
@@ -64,3 +64,8 @@ reference_chain_delay_duration = 0.5
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 1000
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/simulation.rs
@@ -128,6 +128,7 @@ pub async fn run_sweep_block_interval_constant_time_delay() -> Result<(), crate:
                         sim_total_block_number: block_count,  // Use block count from config
                         ..base_config.simulation_config.clone()
                     },
+                    logging_config: base_config.logging_config.clone(),
                 }
             })
         }),

--- a/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
@@ -59,3 +59,8 @@ cat_lifetime_step = 5
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 1000
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_cat_lifetime/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_cat_lifetime/simulation.rs
@@ -78,6 +78,7 @@ pub async fn run_sweep_cat_lifetime_simulation() -> Result<(), crate::config::Co
                         allow_cat_pending_dependencies: base_config.transaction_config.allow_cat_pending_dependencies,
                     },
                     simulation_config: base_config.simulation_config.clone(),
+                    logging_config: base_config.logging_config.clone(),
                 }
             })
         }),

--- a/simulator/src/scenarios/sim_sweep_cat_pending_dependencies/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_pending_dependencies/config.toml
@@ -56,3 +56,8 @@ num_simulations = 2
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 1000
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_cat_pending_dependencies/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_cat_pending_dependencies/simulation.rs
@@ -90,6 +90,7 @@ pub async fn run_sweep_cat_pending_dependencies_simulation() -> Result<(), crate
                         allow_cat_pending_dependencies: allow_cat_pending_dependencies,  // This is the parameter we're varying
                     },
                     simulation_config: base_config.simulation_config.clone(),
+                    logging_config: base_config.logging_config.clone(),
                 }
             })
         }),

--- a/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
@@ -59,3 +59,8 @@ cat_rate_step = 0.05
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 1000
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_cat_rate/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_cat_rate/simulation.rs
@@ -94,6 +94,7 @@ pub async fn run_sweep_cat_rate_simulation() -> Result<(), crate::config::Config
                         allow_cat_pending_dependencies: base_config.transaction_config.allow_cat_pending_dependencies,
                     },
                     simulation_config: base_config.simulation_config.clone(),
+                    logging_config: base_config.logging_config.clone(),
                 }
             })
         }),

--- a/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
@@ -59,3 +59,8 @@ chain_delay_step = 2
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 1000
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_chain_delay/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_chain_delay/simulation.rs
@@ -95,6 +95,7 @@ pub async fn run_sweep_chain_delay() -> Result<(), crate::config::ConfigError> {
                     account_config: base_config.account_config.clone(),
                     transaction_config: base_config.transaction_config.clone(),
                     simulation_config: base_config.simulation_config.clone(),
+                    logging_config: base_config.logging_config.clone(),
                 }
             })
         }),

--- a/simulator/src/scenarios/sim_sweep_total_block_number/config.toml
+++ b/simulator/src/scenarios/sim_sweep_total_block_number/config.toml
@@ -59,3 +59,8 @@ block_number_step = 25
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 1000
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_total_block_number/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_total_block_number/simulation.rs
@@ -94,6 +94,7 @@ pub async fn run_sweep_total_block_number() -> Result<(), crate::config::ConfigE
                         sim_total_block_number: block_number,  // This is the parameter we're varying
                         ..base_config.simulation_config.clone()
                     },
+                    logging_config: base_config.logging_config.clone(),
                 }
             })
         }),

--- a/simulator/src/scenarios/sim_sweep_zipf/config.toml
+++ b/simulator/src/scenarios/sim_sweep_zipf/config.toml
@@ -59,3 +59,8 @@ zipf_step = 0.5
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 1000
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false

--- a/simulator/src/scenarios/sim_sweep_zipf/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_zipf/simulation.rs
@@ -95,6 +95,7 @@ pub async fn run_sweep_zipf_simulation() -> Result<(), crate::config::ConfigErro
                         allow_cat_pending_dependencies: base_config.transaction_config.allow_cat_pending_dependencies,
                     },
                     simulation_config: base_config.simulation_config.clone(),
+                    logging_config: base_config.logging_config.clone(),
                 }
             })
         }),

--- a/simulator/src/testnodes.rs
+++ b/simulator/src/testnodes.rs
@@ -38,8 +38,7 @@ use tokio::sync::Mutex;
 ///
 pub async fn setup_test_nodes(block_interval: Duration, chain_delays: &[u64], allow_cat_pending_dependencies: bool, cat_lifetime_blocks: u64) 
 -> (Arc<Mutex<HyperSchedulerNode>>, Arc<Mutex<ConfirmationLayerNode>>, Arc<Mutex<HyperIGNode>>, Arc<Mutex<HyperIGNode>>, u64) {
-    // Initialize logging
-    logging::init_logging();
+    // Note: Logging should be initialized by the calling code before calling this function
 
     // Create channels for communication
     let (sender_hs_to_cl, receiver_hs_to_cl) = mpsc::channel(100);

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -41,6 +41,27 @@ pub fn init_logging() {
     }
 }
 
+/// Initializes logging with configuration from config file.
+/// 
+/// # Arguments
+/// * `enabled` - Whether logging is enabled
+/// * `log_to_file` - Whether to log to file
+/// * `log_file_path` - Optional log file path (if None, uses default)
+pub fn init_logging_with_config(enabled: bool, log_to_file: bool, log_file_path: Option<String>) {
+    *ENABLE_LOGGING.lock().unwrap() = enabled;
+    *LOG_TO_FILE.lock().unwrap() = log_to_file;
+
+    if enabled && log_to_file {
+        let log_file = log_file_path.unwrap_or_else(|| "hyperplane.log".to_string());
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_file)
+            .expect("Failed to open log file");
+        *LOG_FILE.lock().unwrap() = Some(file);
+    }
+}
+
 pub fn log(prefix: &str, message: &str) {
     if !*ENABLE_LOGGING.lock().unwrap() {
         return;


### PR DESCRIPTION
## Summary

Make simulator logging optional by adding a `LoggingConfig` to the configuration and updating scenarios and sweep runner to respect it.

## Testing
- Ran the simulation successfully
- Verified with `cargo check`