### PR TITLE
[sim] add preloading accounts in HIG

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -91,6 +91,11 @@ TESTS=(
     hyper_ig::tests::timeouts::test_cat_success_should_not_timeout
     hyper_ig::tests::timeouts::test_status_update_before_timeout_should_process
     hyper_ig::tests::timeouts::test_status_update_at_timeout_boundary_should_process
+    hyper_ig::tests::preloaded_accounts::test_preloaded_accounts
+    hyper_ig::tests::preloaded_accounts::test_transactions_with_preloaded_accounts
+    hyper_ig::tests::preloaded_accounts::test_no_preloaded_accounts
+    hyper_ig::tests::preloaded_accounts::test_credit_with_preloaded_accounts
+    hyper_ig::tests::preloaded_accounts::test_simulation_with_preloaded_accounts
 
     # Hyper Scheduler tests
     hyper_scheduler::tests::basic::test_receive_cat_for_unregistered_chain
@@ -133,7 +138,11 @@ TESTS=(
 # Test specific tests
 TESTS2=(
 
-hyper_ig::tests::timeouts::test_cat_timeout_irreversible
+    hyper_ig::tests::preloaded_accounts::test_preloaded_accounts
+    hyper_ig::tests::preloaded_accounts::test_transactions_with_preloaded_accounts
+    hyper_ig::tests::preloaded_accounts::test_no_preloaded_accounts
+    hyper_ig::tests::preloaded_accounts::test_credit_with_preloaded_accounts
+    hyper_ig::tests::preloaded_accounts::test_simulation_with_preloaded_accounts
 
 )
 

--- a/simulator/src/config.rs
+++ b/simulator/src/config.rs
@@ -107,14 +107,12 @@ impl Default for LoggingConfig {
 /// Configuration for simulation execution parameters.
 /// 
 /// This struct defines parameters that control the simulation execution itself,
-/// including timing settings for initialization and funding, retry behavior,
+/// including timing settings for initialization, retry behavior,
 /// repeat settings, and sweep-specific parameters.
 #[derive(Debug, Deserialize, Clone)]
 pub struct SimulationConfig {
     /// Number of blocks to wait after account initialization before starting transaction submission
     pub initialization_wait_blocks: u64,
-    /// Number of blocks to wait for account funding to complete before starting simulation
-    pub funding_wait_blocks: u64,
     /// Maximum number of retry attempts for failed simulation runs
     pub max_retries: usize,
     /// Number of times to run the simulation (results will be averaged)
@@ -154,7 +152,6 @@ impl Default for SimulationConfig {
     fn default() -> Self {
         Self {
             initialization_wait_blocks: 10,
-            funding_wait_blocks: 5,
             max_retries: 3,
             num_runs: 1,
             num_simulations: None,
@@ -234,9 +231,6 @@ pub fn validate_common_fields(
     }
     if simulation_config.initialization_wait_blocks == 0 {
         return Err(ConfigError::ValidationError("Initialization wait blocks must be positive".into()));
-    }
-    if simulation_config.funding_wait_blocks == 0 {
-        return Err(ConfigError::ValidationError("Funding wait blocks must be positive".into()));
     }
     if simulation_config.max_retries == 0 {
         return Err(ConfigError::ValidationError("Max retries must be positive".into()));

--- a/simulator/src/config.rs
+++ b/simulator/src/config.rs
@@ -107,14 +107,12 @@ impl Default for LoggingConfig {
 /// Configuration for simulation execution parameters.
 /// 
 /// This struct defines parameters that control the simulation execution itself,
-/// including timing settings for initialization, retry behavior,
-/// repeat settings, and sweep-specific parameters.
+/// including timing settings for initialization, repeat settings,
+/// and sweep-specific parameters.
 #[derive(Debug, Deserialize, Clone)]
 pub struct SimulationConfig {
     /// Number of blocks to wait after account initialization before starting transaction submission
     pub initialization_wait_blocks: u64,
-    /// Maximum number of retry attempts for failed simulation runs
-    pub max_retries: usize,
     /// Number of times to run the simulation (results will be averaged)
     pub num_runs: u32,
     /// Total number of blocks to simulate (determines simulation duration)
@@ -152,7 +150,6 @@ impl Default for SimulationConfig {
     fn default() -> Self {
         Self {
             initialization_wait_blocks: 10,
-            max_retries: 3,
             num_runs: 1,
             num_simulations: None,
             cat_lifetime_step: None,
@@ -231,9 +228,6 @@ pub fn validate_common_fields(
     }
     if simulation_config.initialization_wait_blocks == 0 {
         return Err(ConfigError::ValidationError("Initialization wait blocks must be positive".into()));
-    }
-    if simulation_config.max_retries == 0 {
-        return Err(ConfigError::ValidationError("Max retries must be positive".into()));
     }
     if simulation_config.num_runs == 0 {
         return Err(ConfigError::ValidationError("Number of runs must be positive".into()));

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -54,7 +54,7 @@ pub use interface::{SimulatorInterface, SimulationType};
 
 // Configuration and network management
 pub use config::Config;
-pub use network::initialize_accounts;
+
 
 // Account selection and statistics
 pub use account_selection::AccountSelectionStats;

--- a/simulator/src/network.rs
+++ b/simulator/src/network.rs
@@ -5,10 +5,8 @@
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use hyperplane::{
-    types::{ChainId, TransactionId, Transaction, CLTransaction, CLTransactionId, SubBlock},
-    confirmation_layer::{ConfirmationLayerNode, ConfirmationLayer},
-    hyper_ig::HyperIG,
-    utils::logging,
+    types::{ChainId, CLTransaction, SubBlock},
+    confirmation_layer::ConfirmationLayerNode,
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -41,119 +39,4 @@ pub async fn create_network(num_nodes: usize, num_chains: usize) -> Vec<Arc<Mute
     nodes
 }
 
-// ------------------------------------------------------------------------------------------------
-// Account Initialization
-// ------------------------------------------------------------------------------------------------
-
-/// Initializes accounts with the specified initial balance and verifies the balances
-pub async fn initialize_accounts(
-    nodes: &[Arc<Mutex<ConfirmationLayerNode>>], 
-    initial_balance: u64, 
-    num_accounts: usize,
-    hig_nodes: Option<&[Arc<Mutex<hyperplane::hyper_ig::node::HyperIGNode>>]>,
-    block_interval: f64,
-    funding_wait_blocks: u64,
-) -> Result<(), Box<dyn std::error::Error>> {
-    logging::log("SIMULATOR", &format!("Initializing accounts with {} tokens each...", initial_balance));
-
-    for node in nodes {
-        let mut node = node.lock().await;
-        
-        // Get registered chains
-        let chains = node.get_registered_chains().await.expect("Failed to get registered chains");
-        
-        // Initialize accounts on each chain
-        for chain_id in chains {
-            logging::log("SIMULATOR", &format!("Initializing accounts for chain {}...", chain_id.0));
-            
-            // Create accounts with initial balance sequentially
-            for account_id in 1..=num_accounts {
-                let tx = Transaction::new(
-                    TransactionId(format!("init-credit-{}", account_id)),
-                    chain_id.clone(),
-                    vec![chain_id.clone()],
-                    format!("REGULAR.credit {} {}", account_id, initial_balance),
-                    CLTransactionId(format!("init-credit-{}", account_id)),
-                ).expect("Failed to create transaction");
-
-                let cl_tx = CLTransaction::new(
-                    CLTransactionId(format!("init-credit-{}", account_id)),
-                    vec![chain_id.clone()],
-                    vec![tx.clone()],
-                ).expect("Failed to create CL transaction");
-
-                if let Ok(_status) = node.submit_transaction(cl_tx).await {
-                    logging::log("SIMULATOR", &format!("Account {} credit submitted to CL node: {}", account_id, tx.data));
-                } else {
-                    logging::log("SIMULATOR", &format!("Failed to submit credit transaction for account {}: {}", account_id, tx.data));
-                }
-            }
-            logging::log("SIMULATOR", &format!("Chain {} all credit transactions submitted to CL node", chain_id.0));
-        }
-    }
-    logging::log("SIMULATOR", "All credit transactions submitted to CL nodes");
-
-    // If HIG nodes are provided, wait for funding to complete and verify balances
-    if let Some(hig_nodes) = hig_nodes {
-        // Wait for funding transactions to complete
-        // Wait for the specified number of blocks to ensure accounts are funded
-        let wait_blocks = funding_wait_blocks;
-        
-        let current_block = nodes[0].lock().await.get_current_block().await.map_err(|e| e.to_string())?;
-        let funding_target_block = current_block + wait_blocks;
-        
-        logging::log("SIMULATOR", &format!("Waiting for {} funding transactions to complete...", num_accounts * 2));
-        logging::log("SIMULATOR", &format!("Block interval: {:.3}s, Waiting for {} blocks ({:.1}s)...", 
-            block_interval, wait_blocks, block_interval * wait_blocks as f64));
-        
-        // Wait for funding transactions to complete
-        loop {
-            let current_block = nodes[0].lock().await.get_current_block().await.map_err(|e| e.to_string())?;
-            logging::log("SIMULATOR", &format!("Waiting for funding transactions to complete... Current block: {}", current_block));
-            if current_block >= funding_target_block {
-                break;
-            }
-            // Sleep for the block interval before checking again
-            tokio::time::sleep(std::time::Duration::from_secs_f64(block_interval)).await;
-        }
-        
-        // Verify that all accounts have been funded correctly
-        logging::log("SIMULATOR", "================================================");
-        logging::log("SIMULATOR", "VERIFYING ACCOUNT BALANCES AFTER FUNDING...");
-        logging::log("SIMULATOR", "================================================");
-        let expected_balance = initial_balance as i64;
-        
-        for (chain_index, hig_node) in hig_nodes.iter().enumerate() {
-            let chain_state = hig_node.lock().await.get_chain_state().await.map_err(|e| e.to_string())?;
-            logging::log("SIMULATOR", &format!("Chain {} state: {:?}", chain_index + 1, chain_state));
-            
-            // Check that all accounts from 1 to num_accounts have the expected balance
-            for account_id in 1..=num_accounts {
-                let account_key = account_id.to_string();
-                let actual_balance = chain_state.get(&account_key).copied().unwrap_or(0);
-                
-                if actual_balance != expected_balance {
-                    let error_msg = format!(
-                        "Account {} on chain {} has incorrect balance: expected {}, got {}",
-                        account_id, chain_index + 1, expected_balance, actual_balance
-                    );
-                    logging::log("SIMULATOR", "================================================");
-                    logging::log("SIMULATOR", &format!("ERROR: {}", error_msg));
-                    logging::log("SIMULATOR", "================================================");
-                    return Err(error_msg.into());
-                }
-            }
-            
-            logging::log("SIMULATOR", &format!("✓ Chain {} account verification successful - all {} accounts have balance {}", 
-                chain_index + 1, num_accounts, expected_balance));
-        }
-        
-        logging::log("SIMULATOR", "================================================");
-        logging::log("SIMULATOR", "✓ ALL ACCOUNT BALANCES VERIFIED SUCCESSFULLY!");
-        logging::log("SIMULATOR", &format!("✓ All {} accounts on both chains have balance {}", num_accounts, expected_balance));
-        logging::log("SIMULATOR", "✓ Funding transactions completed successfully");
-        logging::log("SIMULATOR", "================================================");
-    }
-
-    Ok(())
-} 
+ 

--- a/simulator/src/scenarios/sim_simple/config.toml
+++ b/simulator/src/scenarios/sim_simple/config.toml
@@ -45,11 +45,8 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 2
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
 # Number of times to run the simulation (results will be averaged)
-num_runs = 1
+num_runs = 10
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 200

--- a/simulator/src/scenarios/sim_simple/config.toml
+++ b/simulator/src/scenarios/sim_simple/config.toml
@@ -45,19 +45,16 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 2
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100
 # Number of times to run the simulation (results will be averaged)
-num_runs = 20
+num_runs = 1
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
-sim_total_block_number = 50
+sim_total_block_number = 200
 
 # Logging control for the simulator
 [logging_config]
 # Whether to write logs to a file (true = write to file, false = no logging)
-log_to_file = true
+log_to_file = false

--- a/simulator/src/scenarios/sim_simple/config.toml
+++ b/simulator/src/scenarios/sim_simple/config.toml
@@ -60,4 +60,4 @@ sim_total_block_number = 50
 # Logging control for the simulator
 [logging_config]
 # Whether to write logs to a file (true = write to file, false = no logging)
-log_to_file = false
+log_to_file = true

--- a/simulator/src/scenarios/sim_simple/simulation.rs
+++ b/simulator/src/scenarios/sim_simple/simulation.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::Write;
 use chrono::Local;
 use hyperplane::utils::logging;
+use hyperplane::hyper_ig::HyperIG;
 use std::time::{Duration, Instant};
 use toml;
 use serde_json;
@@ -96,42 +97,54 @@ pub async fn run_simple_simulation() -> Result<(), crate::config::ConfigError> {
             // Initialize simulation results from configuration
             let mut results = initialize_simulation_results(&config);
 
-            logging::log("SIMULATOR", "Setting up test nodes...");
-            // Setup test nodes (with zero delays for funding)
+            logging::log("SIMULATOR", "Setting up test nodes with preloaded accounts...");
+            // Setup test nodes with preloaded accounts from config
             let (_hs_node, cl_node, hig_node_1, hig_node_2, _start_block_height) = crate::testnodes::setup_test_nodes(
                 Duration::from_secs_f64(config.network_config.block_interval),
                 &[0, 0], // Zero delays for funding
                 config.transaction_config.allow_cat_pending_dependencies,
                 config.transaction_config.cat_lifetime_blocks,
-                0, // No preloaded accounts for funding
-                0, // No preload value
+                config.account_config.num_accounts.try_into().unwrap(), // Preload accounts from config
+                config.account_config.initial_balance.try_into().unwrap(), // Preload value from config
             ).await;
             
-            logging::log("SIMULATOR", "Test nodes setup complete, initializing accounts...");
-            // Initialize accounts with initial balance (with zero delays for fast processing)
-            let account_init_result = crate::network::initialize_accounts(
-                &[cl_node.clone()], 
-                config.account_config.initial_balance.try_into().unwrap(), 
-                config.account_config.num_accounts.try_into().unwrap(),
-                Some(&[hig_node_1.clone(), hig_node_2.clone()]),
-                config.network_config.block_interval,
-                config.simulation_config.funding_wait_blocks,
-            ).await;
-
-            logging::log("SIMULATOR", "Account initialization complete, checking result...");
-            // Check if account initialization failed
-            if let Err(e) = account_init_result {
-                retry_count += 1;
-                if retry_count > max_retries {
-                    let error_context = format!(
-                        "Simple simulation failed during run {}/{} after {} retries. Error: {}",
-                        run, num_runs, retry_count, e
-                    );
-                    return Err(crate::config::ConfigError::ValidationError(error_context));
-                }
-                logging::log("SIMULATOR", &format!("Account initialization failed, retrying... (attempt {}/{})", retry_count, max_retries));
-                continue;
+            logging::log("SIMULATOR", &format!("Test nodes setup complete with {} accounts preloaded with {} tokens each", 
+                config.account_config.num_accounts, config.account_config.initial_balance));
+            
+            // Query and log account balances to verify preloading
+            logging::log("SIMULATOR", "=== Verifying Preloaded Account Balances ===");
+            
+            // Check chain-1 account balances
+            let chain_1_state = hig_node_1.lock().await.get_chain_state().await.unwrap();
+            logging::log("SIMULATOR", &format!("Chain-1 state: {} accounts with balances", chain_1_state.len()));
+            
+            // Log first few account balances as examples
+            let mut sorted_accounts: Vec<_> = chain_1_state.iter().collect();
+            sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
+            
+            for (account_id, balance) in sorted_accounts.iter().take(10) {
+                logging::log("SIMULATOR", &format!("Chain-1 Account {}: {} tokens", account_id, balance));
             }
+            if sorted_accounts.len() > 10 {
+                logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
+            }
+            
+            // Check chain-2 account balances
+            let chain_2_state = hig_node_2.lock().await.get_chain_state().await.unwrap();
+            logging::log("SIMULATOR", &format!("Chain-2 state: {} accounts with balances", chain_2_state.len()));
+            
+            // Log first few account balances as examples
+            let mut sorted_accounts: Vec<_> = chain_2_state.iter().collect();
+            sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
+            
+            for (account_id, balance) in sorted_accounts.iter().take(10) {
+                logging::log("SIMULATOR", &format!("Chain-2 Account {}: {} tokens", account_id, balance));
+            }
+            if sorted_accounts.len() > 10 {
+                logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
+            }
+            
+            logging::log("SIMULATOR", "=== Account Balance Verification Complete ===");
             
             // Now set the actual chain delays for the main simulation
             logging::log("SIMULATOR", "Setting actual chain delays for main simulation...");

--- a/simulator/src/scenarios/sim_simple/simulation.rs
+++ b/simulator/src/scenarios/sim_simple/simulation.rs
@@ -103,6 +103,8 @@ pub async fn run_simple_simulation() -> Result<(), crate::config::ConfigError> {
                 &[0, 0], // Zero delays for funding
                 config.transaction_config.allow_cat_pending_dependencies,
                 config.transaction_config.cat_lifetime_blocks,
+                0, // No preloaded accounts for funding
+                0, // No preload value
             ).await;
             
             logging::log("SIMULATOR", "Test nodes setup complete, initializing accounts...");

--- a/simulator/src/scenarios/sim_simple/simulation.rs
+++ b/simulator/src/scenarios/sim_simple/simulation.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::Write;
+
 use chrono::Local;
 use hyperplane::utils::logging;
 use hyperplane::hyper_ig::HyperIG;
@@ -76,137 +76,103 @@ pub async fn run_simple_simulation() -> Result<(), crate::config::ConfigError> {
 
     // Run the simulation multiple times
     for run in 1..=num_runs {
-        let mut retry_count = 0;
-        let max_retries = config.simulation_config.max_retries;
+        logging::log("SIMULATOR", &format!("=== Starting Run {}/{} ===", run, num_runs));
         
-        loop {
-            logging::log("SIMULATOR", &format!("=== Starting Run {}/{} ===", run, num_runs));
-            
-            if retry_count > 0 {
-                logging::log("SIMULATOR", &format!("=== Retry attempt {}/{} for Run {}/{} ===", 
-                    retry_count, max_retries, run, num_runs));
-                // Print retry message on same line using carriage return
-                print!("\r[{}] ++++++++++++++++++++>------------------- Run {}/{} // Reattempts: {}", 
-                    chrono::Local::now().format("%H:%M:%S"),
-                    run, 
-                    num_runs, 
-                    retry_count);
-                std::io::stdout().flush().unwrap();
-            }
-            
-            // Initialize simulation results from configuration
-            let mut results = initialize_simulation_results(&config);
+        // Initialize simulation results from configuration
+        let mut results = initialize_simulation_results(&config);
 
-            logging::log("SIMULATOR", "Setting up test nodes with preloaded accounts...");
-            // Setup test nodes with preloaded accounts from config
-            let (_hs_node, cl_node, hig_node_1, hig_node_2, _start_block_height) = crate::testnodes::setup_test_nodes(
-                Duration::from_secs_f64(config.network_config.block_interval),
-                &[0, 0], // Zero delays for funding
-                config.transaction_config.allow_cat_pending_dependencies,
-                config.transaction_config.cat_lifetime_blocks,
-                config.account_config.num_accounts.try_into().unwrap(), // Preload accounts from config
-                config.account_config.initial_balance.try_into().unwrap(), // Preload value from config
-            ).await;
-            
-            logging::log("SIMULATOR", &format!("Test nodes setup complete with {} accounts preloaded with {} tokens each", 
-                config.account_config.num_accounts, config.account_config.initial_balance));
-            
-            // Query and log account balances to verify preloading
-            logging::log("SIMULATOR", "=== Verifying Preloaded Account Balances ===");
-            
-            // Check chain-1 account balances
-            let chain_1_state = hig_node_1.lock().await.get_chain_state().await.unwrap();
-            logging::log("SIMULATOR", &format!("Chain-1 state: {} accounts with balances", chain_1_state.len()));
-            
-            // Log first few account balances as examples
-            let mut sorted_accounts: Vec<_> = chain_1_state.iter().collect();
-            sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
-            
-            for (account_id, balance) in sorted_accounts.iter().take(10) {
-                logging::log("SIMULATOR", &format!("Chain-1 Account {}: {} tokens", account_id, balance));
-            }
-            if sorted_accounts.len() > 10 {
-                logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
-            }
-            
-            // Check chain-2 account balances
-            let chain_2_state = hig_node_2.lock().await.get_chain_state().await.unwrap();
-            logging::log("SIMULATOR", &format!("Chain-2 state: {} accounts with balances", chain_2_state.len()));
-            
-            // Log first few account balances as examples
-            let mut sorted_accounts: Vec<_> = chain_2_state.iter().collect();
-            sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
-            
-            for (account_id, balance) in sorted_accounts.iter().take(10) {
-                logging::log("SIMULATOR", &format!("Chain-2 Account {}: {} tokens", account_id, balance));
-            }
-            if sorted_accounts.len() > 10 {
-                logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
-            }
-            
-            logging::log("SIMULATOR", "=== Account Balance Verification Complete ===");
-            
-            // Now set the actual chain delays for the main simulation
-            logging::log("SIMULATOR", "Setting actual chain delays for main simulation...");
-            let delay_1_time = Duration::from_secs_f64(config.network_config.block_interval * config.network_config.chain_delays[0] as f64);
-            let delay_2_time = Duration::from_secs_f64(config.network_config.block_interval * config.network_config.chain_delays[1] as f64);
-            hig_node_1.lock().await.set_hs_message_delay(delay_1_time);
-            hig_node_2.lock().await.set_hs_message_delay(delay_2_time);
-            logging::log("SIMULATOR", &format!("Set chain 1 delay to {} blocks ({:?}) and chain 2 delay to {} blocks ({:?})", 
-                config.network_config.chain_delays[0], delay_1_time, config.network_config.chain_delays[1], delay_2_time));
-
-            // Run simulation with run message and retry count
-            let run_message = format!("Run {}/{}", run, num_runs);
-            let simulation_result = crate::run_simulation::run_simulation_with_message_and_retries(
-                cl_node,
-                vec![hig_node_1, hig_node_2],
-                &mut results,
-                Some(run_message),
-                Some(retry_count),
-            ).await;
-
-            // Check if simulation failed
-            if let Err(e) = simulation_result {
-                retry_count += 1;
-                if retry_count > max_retries {
-                    let error_context = format!(
-                        "Simple simulation failed during run {}/{} after {} retries. Error: {}",
-                        run, num_runs, retry_count, e
-                    );
-                    return Err(crate::config::ConfigError::ValidationError(error_context));
-                }
-                logging::log("SIMULATOR", &format!("Simulation failed, retrying... (attempt {}/{})", retry_count, max_retries));
-                continue;
-            }
-
-            // Save this run's results to its own directory
-            let run_dir = format!("simulator/results/sim_simple/data/sim_0/run_{}", run - 1);
-            let save_result = results.save_to_directory(&run_dir).await;
-            
-            if let Err(e) = save_result {
-                retry_count += 1;
-                if retry_count > max_retries {
-                    let error_context = format!(
-                        "Simple simulation failed to save results for run {}/{} after {} retries. Error: {}",
-                        run, num_runs, retry_count, e
-                    );
-                    return Err(crate::config::ConfigError::ValidationError(error_context));
-                }
-                logging::log("SIMULATOR", &format!("Result saving failed, retrying... (attempt {}/{})", retry_count, max_retries));
-                continue;
-            }
-
-            // Success! Break out of retry loop
-            all_results.push(results);
-            
-            let completion_message = if retry_count > 0 {
-                format!("=== Completed Run {}/{} (after {} retries) ===", run, num_runs, retry_count)
-            } else {
-                format!("=== Completed Run {}/{} ===", run, num_runs)
-            };
-            logging::log("SIMULATOR", &completion_message);
-            break;
+        logging::log("SIMULATOR", "Setting up test nodes with preloaded accounts...");
+        // Setup test nodes with preloaded accounts from config
+        let (_hs_node, cl_node, hig_node_1, hig_node_2, _start_block_height) = crate::testnodes::setup_test_nodes(
+            Duration::from_secs_f64(config.network_config.block_interval),
+            &[0, 0], // Zero delays for funding
+            config.transaction_config.allow_cat_pending_dependencies,
+            config.transaction_config.cat_lifetime_blocks,
+            config.account_config.num_accounts.try_into().unwrap(), // Preload accounts from config
+            config.account_config.initial_balance.try_into().unwrap(), // Preload value from config
+        ).await;
+        
+        logging::log("SIMULATOR", &format!("Test nodes setup complete with {} accounts preloaded with {} tokens each", 
+            config.account_config.num_accounts, config.account_config.initial_balance));
+        
+        // Query and log account balances to verify preloading
+        logging::log("SIMULATOR", "=== Verifying Preloaded Account Balances ===");
+        
+        // Check chain-1 account balances
+        let chain_1_state = hig_node_1.lock().await.get_chain_state().await.unwrap();
+        logging::log("SIMULATOR", &format!("Chain-1 state: {} accounts with balances", chain_1_state.len()));
+        
+        // Log first few account balances as examples
+        let mut sorted_accounts: Vec<_> = chain_1_state.iter().collect();
+        sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
+        
+        for (account_id, balance) in sorted_accounts.iter().take(10) {
+            logging::log("SIMULATOR", &format!("Chain-1 Account {}: {} tokens", account_id, balance));
         }
+        if sorted_accounts.len() > 10 {
+            logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
+        }
+        
+        // Check chain-2 account balances
+        let chain_2_state = hig_node_2.lock().await.get_chain_state().await.unwrap();
+        logging::log("SIMULATOR", &format!("Chain-2 state: {} accounts with balances", chain_2_state.len()));
+        
+        // Log first few account balances as examples
+        let mut sorted_accounts: Vec<_> = chain_2_state.iter().collect();
+        sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
+        
+        for (account_id, balance) in sorted_accounts.iter().take(10) {
+            logging::log("SIMULATOR", &format!("Chain-2 Account {}: {} tokens", account_id, balance));
+        }
+        if sorted_accounts.len() > 10 {
+            logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
+        }
+        
+        logging::log("SIMULATOR", "=== Account Balance Verification Complete ===");
+        
+        // Now set the actual chain delays for the main simulation
+        logging::log("SIMULATOR", "Setting actual chain delays for main simulation...");
+        let delay_1_time = Duration::from_secs_f64(config.network_config.block_interval * config.network_config.chain_delays[0] as f64);
+        let delay_2_time = Duration::from_secs_f64(config.network_config.block_interval * config.network_config.chain_delays[1] as f64);
+        hig_node_1.lock().await.set_hs_message_delay(delay_1_time);
+        hig_node_2.lock().await.set_hs_message_delay(delay_2_time);
+        logging::log("SIMULATOR", &format!("Set chain 1 delay to {} blocks ({:?}) and chain 2 delay to {} blocks ({:?})", 
+            config.network_config.chain_delays[0], delay_1_time, config.network_config.chain_delays[1], delay_2_time));
+
+        // Run simulation
+        let run_message = format!("Run {}/{}", run, num_runs);
+        let simulation_result = crate::run_simulation::run_simulation_with_message_and_retries(
+            cl_node,
+            vec![hig_node_1, hig_node_2],
+            &mut results,
+            Some(run_message),
+            None, // No retry count needed
+        ).await;
+
+        // Check if simulation failed
+        if let Err(e) = simulation_result {
+            let error_context = format!(
+                "Simple simulation failed during run {}/{}: {}",
+                run, num_runs, e
+            );
+            return Err(crate::config::ConfigError::ValidationError(error_context));
+        }
+
+        // Save this run's results to its own directory
+        let run_dir = format!("simulator/results/sim_simple/data/sim_0/run_{}", run - 1);
+        let save_result = results.save_to_directory(&run_dir).await;
+        
+        if let Err(e) = save_result {
+            let error_context = format!(
+                "Simple simulation failed to save results for run {}/{}: {}",
+                run, num_runs, e
+            );
+            return Err(crate::config::ConfigError::ValidationError(error_context));
+        }
+
+        // Success!
+        all_results.push(results);
+        logging::log("SIMULATOR", &format!("=== Completed Run {}/{} ===", run, num_runs));
     }
 
     // Complete progress bar (increment once per simulation, not per run)

--- a/simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/config.toml
@@ -45,9 +45,7 @@ allow_cat_pending_dependencies = false
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
+
 # Number of times to run each simulation (results will be averaged)
 num_runs = 20
 # Number of simulations to run in the sweep

--- a/simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/config.toml
@@ -44,9 +44,7 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
+
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100

--- a/simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/config.toml
@@ -45,9 +45,7 @@ allow_cat_pending_dependencies = false
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
+
 # Number of times to run each simulation (results will be averaged)
 num_runs = 20
 # Number of simulations to run in the sweep

--- a/simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/config.toml
@@ -44,9 +44,7 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
+
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100

--- a/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
@@ -45,9 +45,7 @@ allow_cat_pending_dependencies = false
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
+
 # Number of times to run each simulation (results will be averaged)
 num_runs = 20
 # Number of simulations to run in the sweep

--- a/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
@@ -44,9 +44,7 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
+
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100

--- a/simulator/src/scenarios/sim_sweep_cat_pending_dependencies/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_pending_dependencies/config.toml
@@ -43,9 +43,7 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
+
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100

--- a/simulator/src/scenarios/sim_sweep_cat_pending_dependencies/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_pending_dependencies/config.toml
@@ -44,9 +44,7 @@ allow_cat_pending_dependencies = false
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
+
 # Number of times to run each simulation (results will be averaged)
 num_runs = 20
 # Number of simulations to run in the sweep

--- a/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
@@ -44,9 +44,7 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
+
 # Number of times to run each simulation (results will be averaged)
 num_runs = 20
 # Number of simulations to run in the sweep

--- a/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
@@ -44,9 +44,6 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100

--- a/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
@@ -45,9 +45,7 @@ allow_cat_pending_dependencies = false
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
+
 # Number of times to run each simulation (results will be averaged)
 num_runs = 20
 # Number of simulations to run in the sweep

--- a/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
@@ -44,9 +44,7 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
+
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100

--- a/simulator/src/scenarios/sim_sweep_total_block_number/config.toml
+++ b/simulator/src/scenarios/sim_sweep_total_block_number/config.toml
@@ -45,9 +45,7 @@ allow_cat_pending_dependencies = false
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
+
 # Number of times to run each simulation (results will be averaged)
 num_runs = 20
 # Number of simulations to run in the sweep

--- a/simulator/src/scenarios/sim_sweep_total_block_number/config.toml
+++ b/simulator/src/scenarios/sim_sweep_total_block_number/config.toml
@@ -44,9 +44,7 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
+
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100

--- a/simulator/src/scenarios/sim_sweep_zipf/config.toml
+++ b/simulator/src/scenarios/sim_sweep_zipf/config.toml
@@ -45,9 +45,7 @@ allow_cat_pending_dependencies = false
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 
-# Maximum number of retry attempts for failed simulation runs
-# If a run fails this many times, the entire simulation will fail
-max_retries = 100
+
 # Number of times to run each simulation (results will be averaged)
 num_runs = 20
 # Number of simulations to run in the sweep

--- a/simulator/src/scenarios/sim_sweep_zipf/config.toml
+++ b/simulator/src/scenarios/sim_sweep_zipf/config.toml
@@ -44,9 +44,7 @@ allow_cat_pending_dependencies = false
 # Number of blocks to wait before starting transaction submission
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
-# Number of blocks to wait for account funding to complete
-# This ensures all accounts are properly funded before starting simulation
-funding_wait_blocks = 10
+
 # Maximum number of retry attempts for failed simulation runs
 # If a run fails this many times, the entire simulation will fail
 max_retries = 100

--- a/simulator/src/scenarios/sweep_runner.rs
+++ b/simulator/src/scenarios/sweep_runner.rs
@@ -181,163 +181,122 @@ impl<T: std::fmt::Debug + Clone> SweepRunner<T> {
 
             // Store results for all runs of this parameter set
             let mut parameter_results = Vec::new();
-            let mut total_retries_for_simulation = 0;
 
             // Run this parameter set multiple times
             for run in 1..=num_runs {
-                let mut retry_count = 0;
-                let max_retries = sim_config.simulation_config.max_retries;
+                logging::log("SIMULATOR", &format!("=== Starting Run {}/{} for parameter {}: {:?} ===", 
+                    run, num_runs, self.parameter_name, param_value));
+
+                // Initialize simulation results for this run
+                let mut results = self.initialize_simulation_results(&sim_config, sim_index, param_value);
+
+                // Setup test nodes with preloaded accounts from config
+                let (_hs_node, cl_node, hig_node_1, hig_node_2, _start_block_height) = crate::testnodes::setup_test_nodes(
+                    Duration::from_secs_f64(sim_config.network_config.block_interval),
+                    &sim_config.network_config.chain_delays,
+                    sim_config.transaction_config.allow_cat_pending_dependencies,
+                    sim_config.transaction_config.cat_lifetime_blocks,
+                    sim_config.account_config.num_accounts.try_into().unwrap(), // Preload accounts from config
+                    sim_config.account_config.initial_balance.try_into().unwrap(), // Preload value from config
+                ).await;
                 
-                loop {
-                    logging::log("SIMULATOR", &format!("=== Starting Run {}/{} for parameter {}: {:?} ===", 
-                        run, num_runs, self.parameter_name, param_value));
+                logging::log("SIMULATOR", &format!("Test nodes setup complete with {} accounts preloaded with {} tokens each", 
+                    sim_config.account_config.num_accounts, sim_config.account_config.initial_balance));
+                
+                // Query and log account balances to verify preloading (only for first run to avoid spam)
+                if run == 1 {
+                    logging::log("SIMULATOR", "=== Verifying Preloaded Account Balances ===");
                     
-                    if retry_count > 0 {
-                        logging::log("SIMULATOR", &format!("=== Retry attempt {}/{} for Run {}/{} ===", 
-                            retry_count, max_retries, run, num_runs));
-                        // Update progress bar message to show retry count
-                        progress_bar.set_message(self.format_progress_message(sim_index, sweep_config.get_num_simulations(), param_value, Some(total_retries_for_simulation)));
+                    // Check chain-1 account balances
+                    let chain_1_state = hig_node_1.lock().await.get_chain_state().await.unwrap();
+                    logging::log("SIMULATOR", &format!("Chain-1 state: {} accounts with balances", chain_1_state.len()));
+                    
+                    // Log first few account balances as examples
+                    let mut sorted_accounts: Vec<_> = chain_1_state.iter().collect();
+                    sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
+                    
+                    for (account_id, balance) in sorted_accounts.iter().take(10) {
+                        logging::log("SIMULATOR", &format!("Chain-1 Account {}: {} tokens", account_id, balance));
                     }
-
-                    // Initialize simulation results for this run
-                    let mut results = self.initialize_simulation_results(&sim_config, sim_index, param_value);
-
-                    // Setup test nodes with preloaded accounts from config
-                    let (_hs_node, cl_node, hig_node_1, hig_node_2, _start_block_height) = crate::testnodes::setup_test_nodes(
-                        Duration::from_secs_f64(sim_config.network_config.block_interval),
-                        &sim_config.network_config.chain_delays,
-                        sim_config.transaction_config.allow_cat_pending_dependencies,
-                        sim_config.transaction_config.cat_lifetime_blocks,
-                        sim_config.account_config.num_accounts.try_into().unwrap(), // Preload accounts from config
-                        sim_config.account_config.initial_balance.try_into().unwrap(), // Preload value from config
-                    ).await;
-                    
-                    logging::log("SIMULATOR", &format!("Test nodes setup complete with {} accounts preloaded with {} tokens each", 
-                        sim_config.account_config.num_accounts, sim_config.account_config.initial_balance));
-                    
-                    // Query and log account balances to verify preloading (only for first run to avoid spam)
-                    if run == 1 {
-                        logging::log("SIMULATOR", "=== Verifying Preloaded Account Balances ===");
-                        
-                        // Check chain-1 account balances
-                        let chain_1_state = hig_node_1.lock().await.get_chain_state().await.unwrap();
-                        logging::log("SIMULATOR", &format!("Chain-1 state: {} accounts with balances", chain_1_state.len()));
-                        
-                        // Log first few account balances as examples
-                        let mut sorted_accounts: Vec<_> = chain_1_state.iter().collect();
-                        sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
-                        
-                        for (account_id, balance) in sorted_accounts.iter().take(10) {
-                            logging::log("SIMULATOR", &format!("Chain-1 Account {}: {} tokens", account_id, balance));
-                        }
-                        if sorted_accounts.len() > 10 {
-                            logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
-                        }
-                        
-                        // Check chain-2 account balances
-                        let chain_2_state = hig_node_2.lock().await.get_chain_state().await.unwrap();
-                        logging::log("SIMULATOR", &format!("Chain-2 state: {} accounts with balances", chain_2_state.len()));
-                        
-                        // Log first few account balances as examples
-                        let mut sorted_accounts: Vec<_> = chain_2_state.iter().collect();
-                        sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
-                        
-                        for (account_id, balance) in sorted_accounts.iter().take(10) {
-                            logging::log("SIMULATOR", &format!("Chain-2 Account {}: {} tokens", account_id, balance));
-                        }
-                        if sorted_accounts.len() > 10 {
-                            logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
-                        }
-                        
-                        logging::log("SIMULATOR", "=== Account Balance Verification Complete ===");
+                    if sorted_accounts.len() > 10 {
+                        logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
                     }
-
-                    // Run simulation with run message and retry count
-                    let run_message = format!("Sim {} Run {}/{}", sim_index + 1, run, num_runs);
-                    let simulation_result = crate::run_simulation::run_simulation_with_message_and_retries(
-                        cl_node,
-                        vec![hig_node_1, hig_node_2],
-                        &mut results,
-                        Some(run_message),
-                        Some(total_retries_for_simulation),
-                    ).await;
-
-                    // Check if simulation failed
-                    if let Err(e) = simulation_result {
-                        retry_count += 1;
-                        total_retries_for_simulation += 1;
-                        logging::log("SIMULATOR", &format!("DEBUG: Simulation failed. retry_count: {}, total_retries: {}, max_retries: {}", retry_count, total_retries_for_simulation, max_retries));
-                        if total_retries_for_simulation >= max_retries {
-                            let error_context = format!(
-                                "Sweep '{}' failed during simulation {}/{} run {}/{} with {}: {:?} after {} total retries. Error: {}",
-                                self.sweep_name,
-                                sim_index + 1,
-                                sweep_config.get_num_simulations(),
-                                run,
-                                num_runs,
-                                self.parameter_name,
-                                param_value,
-                                total_retries_for_simulation,
-                                e
-                            );
-                            return Err(crate::config::ConfigError::ValidationError(error_context));
-                        }
-                        logging::log("SIMULATOR", &format!("Simulation failed, retrying... (attempt {}/{})", retry_count, max_retries));
-                        // Update progress message to show retry count
-                        progress_bar.set_message(self.format_progress_message(sim_index, sweep_config.get_num_simulations(), param_value, Some(total_retries_for_simulation)));
-                        continue;
-                    }
-
-                    // Save this run's results to its own directory
-                    let run_dir = format!("simulator/results/{}/data/sim_{}/run_{}", self.results_dir, sim_index, run - 1);
-                    let save_result = results.save_to_directory(&run_dir).await;
                     
-                    if let Err(e) = save_result {
-                        retry_count += 1;
-                        total_retries_for_simulation += 1;
-                        logging::log("SIMULATOR", &format!("DEBUG: Save failed. retry_count: {}, total_retries: {}, max_retries: {}", retry_count, total_retries_for_simulation, max_retries));
-                        if total_retries_for_simulation >= max_retries {
-                            let error_context = format!(
-                                "Sweep '{}' failed to save results for simulation {}/{} run {}/{} with {}: {:?} after {} total retries. Error: {}",
-                                self.sweep_name,
-                                sim_index + 1,
-                                sweep_config.get_num_simulations(),
-                                run,
-                                num_runs,
-                                self.parameter_name,
-                                param_value,
-                                total_retries_for_simulation,
-                                e
-                            );
-                            return Err(crate::config::ConfigError::ValidationError(error_context));
-                        }
-                        logging::log("SIMULATOR", &format!("Result saving failed, retrying... (attempt {}/{})", retry_count, max_retries));
-                        // Update progress message to show retry count
-                        progress_bar.set_message(self.format_progress_message(sim_index, sweep_config.get_num_simulations(), param_value, Some(total_retries_for_simulation)));
-                        continue;
-                    }
-
-                    // Success! Break out of retry loop
-                    parameter_results.push(results);
+                    // Check chain-2 account balances
+                    let chain_2_state = hig_node_2.lock().await.get_chain_state().await.unwrap();
+                    logging::log("SIMULATOR", &format!("Chain-2 state: {} accounts with balances", chain_2_state.len()));
                     
-                    let completion_message = if retry_count > 0 {
-                        format!("=== Completed Run {}/{} for parameter {}: {:?} (after {} retries) ===", 
-                            run, num_runs, self.parameter_name, param_value, retry_count)
-                    } else {
-                        format!("=== Completed Run {}/{} for parameter {}: {:?} ===", 
-                            run, num_runs, self.parameter_name, param_value)
-                    };
-                    logging::log("SIMULATOR", &completion_message);
-                    break;
+                    // Log first few account balances as examples
+                    let mut sorted_accounts: Vec<_> = chain_2_state.iter().collect();
+                    sorted_accounts.sort_by_key(|(account_id, _)| account_id.parse::<u32>().unwrap_or(0));
+                    
+                    for (account_id, balance) in sorted_accounts.iter().take(10) {
+                        logging::log("SIMULATOR", &format!("Chain-2 Account {}: {} tokens", account_id, balance));
+                    }
+                    if sorted_accounts.len() > 10 {
+                        logging::log("SIMULATOR", &format!("... and {} more accounts", sorted_accounts.len() - 10));
+                    }
+                    
+                    logging::log("SIMULATOR", "=== Account Balance Verification Complete ===");
                 }
+
+                // Run simulation
+                let run_message = format!("Sim {} Run {}/{}", sim_index + 1, run, num_runs);
+                let simulation_result = crate::run_simulation::run_simulation_with_message_and_retries(
+                    cl_node,
+                    vec![hig_node_1, hig_node_2],
+                    &mut results,
+                    Some(run_message),
+                    None, // No retry count needed
+                ).await;
+
+                // Check if simulation failed
+                if let Err(e) = simulation_result {
+                    let error_context = format!(
+                        "Sweep '{}' failed during simulation {}/{} run {}/{} with {}: {:?}. Error: {}",
+                        self.sweep_name,
+                        sim_index + 1,
+                        sweep_config.get_num_simulations(),
+                        run,
+                        num_runs,
+                        self.parameter_name,
+                        param_value,
+                        e
+                    );
+                    return Err(crate::config::ConfigError::ValidationError(error_context));
+                }
+
+                // Save this run's results to its own directory
+                let run_dir = format!("simulator/results/{}/data/sim_{}/run_{}", self.results_dir, sim_index, run - 1);
+                let save_result = results.save_to_directory(&run_dir).await;
+                
+                if let Err(e) = save_result {
+                    let error_context = format!(
+                        "Sweep '{}' failed to save results for simulation {}/{} run {}/{} with {}: {:?}. Error: {}",
+                        self.sweep_name,
+                        sim_index + 1,
+                        sweep_config.get_num_simulations(),
+                        run,
+                        num_runs,
+                        self.parameter_name,
+                        param_value,
+                        e
+                    );
+                    return Err(crate::config::ConfigError::ValidationError(error_context));
+                }
+
+                // Success!
+                parameter_results.push(results);
+                logging::log("SIMULATOR", &format!("=== Completed Run {}/{} for parameter {}: {:?} ===", 
+                    run, num_runs, self.parameter_name, param_value));
             }
 
             // Use the first run's results for the sweep summary (individual runs are saved separately)
             all_results.push((param_value.clone(), parameter_results[0].clone()));
             
-            // Update progress bar and show completed simulation with retry count
+            // Update progress bar
             progress_bar.inc(1);
-            progress_bar.set_message(self.format_progress_message(sim_index, sweep_config.get_num_simulations(), param_value, Some(total_retries_for_simulation)));
+            progress_bar.set_message(self.format_progress_message(sim_index, sweep_config.get_num_simulations(), param_value, None));
         }
 
         // Finish progress bar with final state
@@ -535,7 +494,6 @@ impl<T: std::fmt::Debug + Clone> SweepRunner<T> {
         logging::log("SIMULATOR", &format!("CAT Ratio: {}", config.transaction_config.ratio_cats));
         logging::log("SIMULATOR", &format!("CAT Lifetime: {} blocks", results.cat_lifetime));
         logging::log("SIMULATOR", &format!("Initialization Wait Blocks: {}", results.initialization_wait_blocks));
-        logging::log("SIMULATOR", &format!("Max Retries: {}", config.simulation_config.max_retries));
         for (i, delay) in config.network_config.chain_delays.iter().enumerate() {
             logging::log("SIMULATOR", &format!("Chain {} Delay: {} blocks", i + 1, delay));
         }

--- a/simulator/src/scenarios/sweep_runner.rs
+++ b/simulator/src/scenarios/sweep_runner.rs
@@ -207,6 +207,8 @@ impl<T: std::fmt::Debug + Clone> SweepRunner<T> {
                         &sim_config.network_config.chain_delays,
                         sim_config.transaction_config.allow_cat_pending_dependencies,
                         sim_config.transaction_config.cat_lifetime_blocks,
+                        0, // No preloaded accounts for sweep simulations
+                        0, // No preload value
                     ).await;
                     
                     // Initialize accounts with initial balance

--- a/simulator/src/testnodes.rs
+++ b/simulator/src/testnodes.rs
@@ -27,6 +27,9 @@ use tokio::sync::Mutex;
 /// * `block_interval` - The block interval to use for the confirmation layer node
 /// * `chain_delays` - The delays to use for the hyperig nodes (in blocks)
 /// * `allow_cat_pending_dependencies` - Whether to allow CATs to depend on locked keys
+/// * `cat_lifetime_blocks` - The default lifetime for CATs in blocks
+/// * `num_accounts` - Number of accounts to preload (0 for no preloading)
+/// * `preload_value` - Value to preload each account with
 ///
 /// # Returns
 ///
@@ -36,7 +39,7 @@ use tokio::sync::Mutex;
 /// * `hig_node_2` - The hyperig node for chain-2
 /// * `current_block` - The current block number at the end of the setup
 ///
-pub async fn setup_test_nodes(block_interval: Duration, chain_delays: &[u64], allow_cat_pending_dependencies: bool, cat_lifetime_blocks: u64) 
+pub async fn setup_test_nodes(block_interval: Duration, chain_delays: &[u64], allow_cat_pending_dependencies: bool, cat_lifetime_blocks: u64, num_accounts: u32, preload_value: u32) 
 -> (Arc<Mutex<HyperSchedulerNode>>, Arc<Mutex<ConfirmationLayerNode>>, Arc<Mutex<HyperIGNode>>, Arc<Mutex<HyperIGNode>>, u64) {
     // Note: Logging should be initialized by the calling code before calling this function
 
@@ -53,8 +56,8 @@ pub async fn setup_test_nodes(block_interval: Duration, chain_delays: &[u64], al
         receiver_hs_to_cl,
         block_interval,
     ).expect("Failed to create confirmation node")));
-    let hig_node_1 = Arc::new(Mutex::new(HyperIGNode::new(receiver_cl_to_hig1, sender_hig1_to_hs, ChainId("chain-1".to_string()), cat_lifetime_blocks, allow_cat_pending_dependencies)));
-    let hig_node_2 = Arc::new(Mutex::new(HyperIGNode::new(receiver_cl_to_hig2, sender_hig2_to_hs, ChainId("chain-2".to_string()), cat_lifetime_blocks, allow_cat_pending_dependencies)));
+    let hig_node_1 = Arc::new(Mutex::new(HyperIGNode::new_with_preloaded_accounts(receiver_cl_to_hig1, sender_hig1_to_hs, ChainId("chain-1".to_string()), cat_lifetime_blocks, allow_cat_pending_dependencies, num_accounts, preload_value)));
+    let hig_node_2 = Arc::new(Mutex::new(HyperIGNode::new_with_preloaded_accounts(receiver_cl_to_hig2, sender_hig2_to_hs, ChainId("chain-2".to_string()), cat_lifetime_blocks, allow_cat_pending_dependencies, num_accounts, preload_value)));
 
     // Start the nodes
     HyperSchedulerNode::start(hs_node.clone()).await;

--- a/src/hyper_ig/tests/mod.rs
+++ b/src/hyper_ig/tests/mod.rs
@@ -2,3 +2,4 @@
 mod basic;
 mod dependencies;
 mod timeouts;
+mod preloaded_accounts;

--- a/src/hyper_ig/tests/preloaded_accounts.rs
+++ b/src/hyper_ig/tests/preloaded_accounts.rs
@@ -1,0 +1,305 @@
+use crate::{
+    types::{Transaction, TransactionId, TransactionStatus, ChainId, CLTransactionId},
+    hyper_ig::{HyperIG, node::HyperIGNode},
+};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+use hyperplane::utils::logging;
+
+/// Helper function to set up a test HIG node with preloaded accounts
+pub async fn setup_test_hig_node_with_preloaded_accounts(num_accounts: u32, preload_value: u32) -> Arc<Mutex<HyperIGNode>> {
+    let (_sender_cl_to_hig, receiver_cl_to_hig) = mpsc::channel(100);
+    let (sender_hig_to_hs, _receiver_hig_to_hs) = mpsc::channel(100);
+    
+    let hig_node = HyperIGNode::new_with_preloaded_accounts(
+        receiver_cl_to_hig, 
+        sender_hig_to_hs, 
+        ChainId("test-chain".to_string()), 
+        4, 
+        true, 
+        num_accounts, 
+        preload_value
+    );
+    let hig_node = Arc::new(Mutex::new(hig_node));
+    
+    // Start the node
+    HyperIGNode::start(hig_node.clone()).await;
+
+    hig_node
+}
+
+/// Tests that accounts are properly preloaded with the specified value when creating a HyperIG node.
+/// 
+/// This test verifies the core preloading functionality by ensuring that when a HyperIG node
+/// is created with preloaded accounts, all specified accounts are initialized with the correct
+/// balance. This is essential for simulation scenarios where we need predictable initial states.
+/// 
+/// Test flow:
+/// 1. Creates a HyperIG node with 5 accounts preloaded with 100 tokens each
+/// 2. Retrieves the chain state to verify account balances
+/// 3. Verifies each account from 1 to 5 has exactly 100 tokens
+/// 4. Confirms no additional accounts exist beyond the specified count
+/// 
+/// This test ensures that the preloading mechanism works correctly and provides
+/// a reliable foundation for simulation testing.
+#[tokio::test]
+async fn test_preloaded_accounts() {
+    logging::init_logging();
+    logging::log("TEST", "\n=== Starting test_preloaded_accounts ===");
+    
+    let num_accounts = 5;
+    let preload_value = 100;
+    
+    logging::log("TEST", &format!("Setting up HyperIG node with {} accounts preloaded with {} tokens each", num_accounts, preload_value));
+    let hig_node = setup_test_hig_node_with_preloaded_accounts(num_accounts, preload_value).await;
+    logging::log("TEST", "HyperIG node setup complete");
+    
+    // Get the chain state and verify all accounts are preloaded
+    logging::log("TEST", "Retrieving chain state to verify preloaded accounts...");
+    let state = hig_node.lock().await.get_chain_state().await.unwrap();
+    logging::log("TEST", &format!("Chain state: {:?}", state));
+    
+    // Verify all accounts from 1 to num_accounts have the preload_value
+    logging::log("TEST", "Verifying account balances...");
+    for account_id in 1..=num_accounts {
+        let account_key = account_id.to_string();
+        let balance = state.get(&account_key).copied().unwrap_or(0);
+        assert_eq!(balance, preload_value as i64, "Account {} should have balance {}", account_id, preload_value);
+        logging::log("TEST", &format!("✓ Account {} has correct balance: {}", account_id, balance));
+    }
+    
+    // Verify no other accounts exist
+    assert_eq!(state.len(), num_accounts as usize, "Should have exactly {} accounts", num_accounts);
+    logging::log("TEST", &format!("✓ Verified exactly {} accounts exist", num_accounts));
+    
+    logging::log("TEST", "=== Test completed successfully ===\n");
+}
+
+/// Tests that send transactions work correctly with preloaded accounts.
+/// 
+/// This test verifies that the preloaded account functionality integrates properly
+/// with the transaction processing system. It ensures that transactions can be
+/// executed between preloaded accounts and that balances are updated correctly.
+/// 
+/// Test flow:
+/// 1. Creates a HyperIG node with 3 accounts preloaded with 200 tokens each
+/// 2. Executes a send transaction from account 1 to account 2 for 50 tokens
+/// 3. Verifies the transaction succeeds
+/// 4. Checks that account 1 balance is reduced to 150 (200 - 50)
+/// 5. Checks that account 2 balance is increased to 250 (200 + 50)
+/// 6. Confirms account 3 balance remains unchanged at 200
+/// 
+/// This test ensures that preloaded accounts can participate in normal transaction
+/// processing without any issues.
+#[tokio::test]
+async fn test_transactions_with_preloaded_accounts() {
+    logging::init_logging();
+    logging::log("TEST", "\n=== Starting test_transactions_with_preloaded_accounts ===");
+    
+    let num_accounts = 3;
+    let preload_value = 200;
+    
+    logging::log("TEST", &format!("Setting up HyperIG node with {} accounts preloaded with {} tokens each", num_accounts, preload_value));
+    let hig_node = setup_test_hig_node_with_preloaded_accounts(num_accounts, preload_value).await;
+    logging::log("TEST", "HyperIG node setup complete");
+    
+    // Test a send transaction between preloaded accounts
+    let cl_id = CLTransactionId("cl-tx".to_string());
+    let tx = Transaction::new(
+        TransactionId(format!("{:?}:send_tx", cl_id)),
+        ChainId("test-chain".to_string()),
+        vec![ChainId("test-chain".to_string())],
+        "REGULAR.send 1 2 50".to_string(),
+        cl_id.clone(),
+    ).expect("Failed to create transaction");
+    
+    logging::log("TEST", "Executing send transaction from account 1 to account 2 for 50 tokens...");
+    let status = hig_node.lock().await.process_transaction(tx).await.unwrap();
+    assert_eq!(status, TransactionStatus::Success, "Send transaction should succeed with sufficient funds");
+    logging::log("TEST", "✓ Send transaction executed successfully");
+    
+    // Verify the balances are updated correctly
+    logging::log("TEST", "Verifying updated account balances...");
+    let state = hig_node.lock().await.get_chain_state().await.unwrap();
+    assert_eq!(state.get("1"), Some(&150), "Account 1 should have balance 150 (200 - 50)");
+    assert_eq!(state.get("2"), Some(&250), "Account 2 should have balance 250 (200 + 50)");
+    assert_eq!(state.get("3"), Some(&200), "Account 3 should still have balance 200");
+    
+    logging::log("TEST", "✓ All account balances updated correctly");
+    logging::log("TEST", "=== Test completed successfully ===\n");
+}
+
+/// Tests that no accounts are preloaded when the preload count is set to zero.
+/// 
+/// This test verifies the edge case where no preloading is requested, ensuring
+/// that the system behaves correctly when preloading is disabled. This is important
+/// for scenarios where we want to start with completely empty accounts.
+/// 
+/// Test flow:
+/// 1. Creates a HyperIG node with 0 accounts to preload
+/// 2. Retrieves the chain state
+/// 3. Verifies that no accounts exist in the state
+/// 
+/// This test ensures that the preloading system gracefully handles the case
+/// where no preloading is desired, maintaining clean state initialization.
+#[tokio::test]
+async fn test_no_preloaded_accounts() {
+    logging::init_logging();
+    logging::log("TEST", "\n=== Starting test_no_preloaded_accounts ===");
+    
+    logging::log("TEST", "Setting up HyperIG node with 0 preloaded accounts");
+    let hig_node = setup_test_hig_node_with_preloaded_accounts(0, 100).await;
+    logging::log("TEST", "HyperIG node setup complete");
+    
+    // Get the chain state and verify no accounts are preloaded
+    logging::log("TEST", "Retrieving chain state to verify no accounts exist...");
+    let state = hig_node.lock().await.get_chain_state().await.unwrap();
+    assert!(state.is_empty(), "Should have no preloaded accounts when count is 0");
+    
+    logging::log("TEST", "✓ Verified no accounts exist in chain state");
+    logging::log("TEST", "=== Test completed successfully ===\n");
+}
+
+/// Tests that credit transactions work correctly with preloaded accounts.
+/// 
+/// This test verifies that credit transactions can be executed on preloaded accounts
+/// and that the balances are updated correctly. This is important for scenarios
+/// where we need to add additional funds to preloaded accounts during simulation.
+/// 
+/// Test flow:
+/// 1. Creates a HyperIG node with 2 accounts preloaded with 50 tokens each
+/// 2. Executes a credit transaction adding 75 tokens to account 1
+/// 3. Verifies the transaction succeeds
+/// 4. Checks that account 1 balance is increased to 125 (50 + 75)
+/// 5. Confirms account 2 balance remains unchanged at 50
+/// 
+/// This test ensures that preloaded accounts can receive additional credits
+/// and that the balance arithmetic works correctly.
+#[tokio::test]
+async fn test_credit_with_preloaded_accounts() {
+    logging::init_logging();
+    logging::log("TEST", "\n=== Starting test_credit_with_preloaded_accounts ===");
+    
+    let num_accounts = 2;
+    let preload_value = 50;
+    
+    logging::log("TEST", &format!("Setting up HyperIG node with {} accounts preloaded with {} tokens each", num_accounts, preload_value));
+    let hig_node = setup_test_hig_node_with_preloaded_accounts(num_accounts, preload_value).await;
+    logging::log("TEST", "HyperIG node setup complete");
+    
+    // Test a credit transaction to an existing account
+    let cl_id = CLTransactionId("cl-tx".to_string());
+    let tx = Transaction::new(
+        TransactionId(format!("{:?}:credit_tx", cl_id)),
+        ChainId("test-chain".to_string()),
+        vec![ChainId("test-chain".to_string())],
+        "REGULAR.credit 1 75".to_string(),
+        cl_id.clone(),
+    ).expect("Failed to create transaction");
+    
+    logging::log("TEST", "Executing credit transaction adding 75 tokens to account 1...");
+    let status = hig_node.lock().await.process_transaction(tx).await.unwrap();
+    assert_eq!(status, TransactionStatus::Success, "Credit transaction should succeed");
+    logging::log("TEST", "✓ Credit transaction executed successfully");
+    
+    // Verify the balance is updated correctly
+    logging::log("TEST", "Verifying updated account balances...");
+    let state = hig_node.lock().await.get_chain_state().await.unwrap();
+    assert_eq!(state.get("1"), Some(&125), "Account 1 should have balance 125 (50 + 75)");
+    assert_eq!(state.get("2"), Some(&50), "Account 2 should still have balance 50");
+    
+    logging::log("TEST", "✓ Account balances updated correctly after credit");
+    logging::log("TEST", "=== Test completed successfully ===\n");
+}
+
+/// Comprehensive test demonstrating a realistic simulation scenario with preloaded accounts.
+/// 
+/// This test simulates a complex scenario with multiple accounts and transactions
+/// to verify that the preloaded accounts functionality works correctly in realistic
+/// simulation conditions. It tests various transaction types and verifies that
+/// all balance calculations are accurate throughout the simulation.
+/// 
+/// Test flow:
+/// 1. Creates a HyperIG node with 10 accounts preloaded with 1000 tokens each
+/// 2. Executes a series of 5 transactions including sends and credits
+/// 3. Verifies each transaction succeeds
+/// 4. Checks final balances for all accounts against expected values
+/// 5. Validates that the simulation maintains consistency throughout
+/// 
+/// This test ensures that preloaded accounts can handle complex simulation
+/// scenarios with multiple transactions and maintain accurate state throughout.
+#[tokio::test]
+async fn test_simulation_with_preloaded_accounts() {
+    logging::init_logging();
+    logging::log("TEST", "\n=== Starting test_simulation_with_preloaded_accounts ===");
+    
+    // Simulate a scenario with 10 accounts, each preloaded with 1000 tokens
+    let num_accounts = 10;
+    let preload_value = 1000;
+    
+    logging::log("TEST", &format!("Setting up HyperIG node with {} accounts preloaded with {} tokens each", num_accounts, preload_value));
+    let hig_node = setup_test_hig_node_with_preloaded_accounts(num_accounts, preload_value).await;
+    logging::log("TEST", "HyperIG node setup complete");
+    
+    // Verify initial state
+    logging::log("TEST", "Verifying initial account state...");
+    let initial_state = hig_node.lock().await.get_chain_state().await.unwrap();
+    logging::log("TEST", &format!("Initial state: {:?}", initial_state));
+    
+    // Simulate a series of transactions
+    let transactions = vec![
+        ("send 1 5 100", "Account 1 sends 100 to account 5"),
+        ("send 2 8 200", "Account 2 sends 200 to account 8"),
+        ("send 3 10 150", "Account 3 sends 150 to account 10"),
+        ("credit 7 500", "Credit 500 to account 7"),
+        ("send 4 6 75", "Account 4 sends 75 to account 6"),
+    ];
+    
+    logging::log("TEST", "Executing series of transactions...");
+    for (i, (tx_data, description)) in transactions.iter().enumerate() {
+        let cl_id = CLTransactionId(format!("cl-tx-{}", i));
+        let tx = Transaction::new(
+            TransactionId(format!("{:?}:{}", cl_id, i)),
+            ChainId("test-chain".to_string()),
+            vec![ChainId("test-chain".to_string())],
+            format!("REGULAR.{}", tx_data),
+            cl_id.clone(),
+        ).expect("Failed to create transaction");
+        
+        logging::log("TEST", &format!("Executing transaction {}: {}", i + 1, description));
+        let status = hig_node.lock().await.process_transaction(tx).await.unwrap();
+        assert_eq!(status, TransactionStatus::Success, "Transaction {} should succeed", i + 1);
+        logging::log("TEST", &format!("✓ Transaction {} completed successfully", i + 1));
+    }
+    
+    // Verify final state
+    logging::log("TEST", "Verifying final account balances...");
+    let final_state = hig_node.lock().await.get_chain_state().await.unwrap();
+    logging::log("TEST", &format!("Final state: {:?}", final_state));
+    
+    // Verify specific account balances
+    let expected_balances = vec![
+        (1, 900),   // 1000 - 100
+        (2, 800),   // 1000 - 200
+        (3, 850),   // 1000 - 150
+        (4, 925),   // 1000 - 75 + 500
+        (5, 1100),  // 1000 + 100
+        (6, 1075),  // 1000 + 75
+        (7, 1500),  // 1000 + 500
+        (8, 1200),  // 1000 + 200
+        (9, 1000),  // unchanged
+        (10, 1150), // 1000 + 150
+    ];
+    
+    logging::log("TEST", "Validating final account balances...");
+    for (account_id, expected_balance) in expected_balances {
+        let actual_balance = final_state.get(&account_id.to_string()).copied().unwrap_or(0);
+        assert_eq!(actual_balance, expected_balance as i64, 
+            "Account {} should have balance {}", account_id, expected_balance);
+        logging::log("TEST", &format!("✓ Account {} has correct balance: {}", account_id, actual_balance));
+    }
+    
+    logging::log("TEST", "✓ Simulation with preloaded accounts completed successfully");
+    logging::log("TEST", "=== Test completed successfully ===\n");
+} 

--- a/src/mock_vm/mod.rs
+++ b/src/mock_vm/mod.rs
@@ -55,6 +55,15 @@ impl MockVM {
     pub fn get_state(&self) -> &HashMap<u32, u32> {
         &self.state
     }
+
+    /// Preload an account with a specified balance
+    /// 
+    /// # Arguments
+    /// * `account_id` - The account ID to preload
+    /// * `balance` - The balance to set for the account
+    pub fn preload_account(&mut self, account_id: u32, balance: u32) {
+        self.state.insert(account_id, balance);
+    }
 }
 
 #[cfg(test)]

--- a/tests/integration/common/testnodes.rs
+++ b/tests/integration/common/testnodes.rs
@@ -15,6 +15,13 @@ use tokio::sync::Mutex;
 /// Returns a tuple of the nodes and the current block number at the end of the setup
 pub async fn setup_test_nodes(block_interval: Duration) 
 -> (Arc<Mutex<HyperSchedulerNode>>, Arc<Mutex<ConfirmationLayerNode>>, Arc<Mutex<HyperIGNode>>, Arc<Mutex<HyperIGNode>>, u64) {
+    setup_test_nodes_with_preloaded_accounts(block_interval, 0, 0).await
+}
+
+/// Helper function to create test nodes with preloaded accounts
+/// Returns a tuple of the nodes and the current block number at the end of the setup
+pub async fn setup_test_nodes_with_preloaded_accounts(block_interval: Duration, num_accounts: u32, preload_value: u32) 
+-> (Arc<Mutex<HyperSchedulerNode>>, Arc<Mutex<ConfirmationLayerNode>>, Arc<Mutex<HyperIGNode>>, Arc<Mutex<HyperIGNode>>, u64) {
     // Initialize logging
     logging::init_logging();
     
@@ -31,8 +38,8 @@ pub async fn setup_test_nodes(block_interval: Duration)
         receiver_hs_to_cl,
         block_interval,
     ).expect("Failed to create confirmation node")));
-    let hig_node_1 = Arc::new(Mutex::new(HyperIGNode::new(receiver_cl_to_hig1, sender_hig1_to_hs, ChainId("chain-1".to_string()), 4, true)));
-    let hig_node_2 = Arc::new(Mutex::new(HyperIGNode::new(receiver_cl_to_hig2, sender_hig2_to_hs, ChainId("chain-2".to_string()), 4, true)));
+    let hig_node_1 = Arc::new(Mutex::new(HyperIGNode::new_with_preloaded_accounts(receiver_cl_to_hig1, sender_hig1_to_hs, ChainId("chain-1".to_string()), 4, true, num_accounts, preload_value)));
+    let hig_node_2 = Arc::new(Mutex::new(HyperIGNode::new_with_preloaded_accounts(receiver_cl_to_hig2, sender_hig2_to_hs, ChainId("chain-2".to_string()), 4, true, num_accounts, preload_value)));
 
     // Start the nodes
     HyperSchedulerNode::start(hs_node.clone()).await;


### PR DESCRIPTION
## Summary

This PR adds support for **preloading accounts** in the HyperIG node and simulator.

### Highlights
- Adds a new `new_with_preloaded_accounts` constructor for `HyperIGNode`
- Updates the simulator to support preloading accounts with an initial balance
- Removes redundant funding wait logic since preloading makes it unnecessary
- Adds comprehensive unit tests for preloaded accounts


## Changes

- `MockVM` now supports `preload_account`
- `setup_test_nodes` and related helpers now accept `num_accounts` and `preload_value`
- New tests under `hyper_ig::tests::preloaded_accounts` verify:
  - Accounts are correctly preloaded
  - Send and credit transactions work on preloaded accounts
  - End-to-end simulation with preloaded accounts runs correctly
- Updates to `config.toml` to remove unused funding wait blocks


## Testing

- ✅ Ran `cargo test` — all unit tests pass, including new preloaded account tests
- ✅ Ran the simulator

