### PR TITLE
[HIG] timed out cats were not removed correctly, fix counters

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -113,6 +113,7 @@ TESTS=(
     hyper_ig::tests::counter_management::test_cat_status_update_with_credit_1000_success
     hyper_ig::tests::counter_management::test_cat_timeout_counter_management
     hyper_ig::tests::counter_management::test_cat_accumulation_management
+    hyper_ig::tests::counter_management::test_postponed_to_resolving_transition
 
     # Hyper Scheduler tests
     hyper_scheduler::tests::basic::test_receive_cat_for_unregistered_chain
@@ -156,13 +157,7 @@ TESTS=(
 )
 
 TESTS2=(
-    hyper_ig::tests::basic::test_cat_pending_dependency_restriction
-    hyper_ig::tests::basic::test_cat_pending_when_depending_on_resolving_cat_failure
-    hyper_ig::tests::basic::test_cat_pending_when_depending_on_resolving_cat_success
-    hyper_ig::tests::counter_management::test_cat_accumulation_management
-    hyper_ig::tests::counter_management::test_cat_timeout_counter_management
-    hyper_ig::tests::timeouts::test_cat_timeout
-    hyper_ig::tests::timeouts::test_cat_timeout_irreversible
+    hyper_ig::tests::counter_management::test_postponed_to_resolving_transition
 )
 
 # Check if arguments are provided

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -106,6 +106,13 @@ TESTS=(
     hyper_ig::tests::shutdown::test_hig_node_shutdown
     hyper_ig::tests::shutdown::test_hig_node_shutdown_multiple_times
     hyper_ig::tests::shutdown::test_hig_node_restart_after_shutdown
+    hyper_ig::tests::counter_management::test_add_to_pending_and_increment_counter
+    hyper_ig::tests::counter_management::test_update_to_final_status_and_update_counter
+    hyper_ig::tests::counter_management::test_counter_consistency_on_reprocessing
+    hyper_ig::tests::counter_management::test_cat_status_update_with_credit_100_failure
+    hyper_ig::tests::counter_management::test_cat_status_update_with_credit_1000_success
+    hyper_ig::tests::counter_management::test_cat_timeout_counter_management
+    hyper_ig::tests::counter_management::test_cat_accumulation_management
 
     # Hyper Scheduler tests
     hyper_scheduler::tests::basic::test_receive_cat_for_unregistered_chain
@@ -148,13 +155,14 @@ TESTS=(
     integration::e2e::test_hig_delays
 )
 
-# Test specific tests
 TESTS2=(
-    hyper_ig::tests::counter_management::test_add_to_pending_and_increment_counter
-    hyper_ig::tests::counter_management::test_update_to_final_status_and_update_counter
-    hyper_ig::tests::counter_management::test_counter_consistency_on_reprocessing
-    hyper_ig::tests::counter_management::test_cat_status_update_with_credit_100_failure
-    hyper_ig::tests::counter_management::test_cat_status_update_with_credit_1000_success
+    hyper_ig::tests::basic::test_cat_pending_dependency_restriction
+    hyper_ig::tests::basic::test_cat_pending_when_depending_on_resolving_cat_failure
+    hyper_ig::tests::basic::test_cat_pending_when_depending_on_resolving_cat_success
+    hyper_ig::tests::counter_management::test_cat_accumulation_management
+    hyper_ig::tests::counter_management::test_cat_timeout_counter_management
+    hyper_ig::tests::timeouts::test_cat_timeout
+    hyper_ig::tests::timeouts::test_cat_timeout_irreversible
 )
 
 # Check if arguments are provided

--- a/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
@@ -47,7 +47,7 @@ initialization_wait_blocks = 10
 # Number of times to run each simulation (results will be averaged)
 num_runs = 1
 # Number of simulations to run in the sweep
-num_simulations = 5
+num_simulations = 20
 # Step size for CAT ratio sweeps
 cat_rate_step = 0.05
 # Total number of blocks to simulate
@@ -66,4 +66,4 @@ plot_moving_average = true
 # How many consecutive data points get averaged
 range_moving_average = 20
 # cuts off data at sim_total_block_number * cutoff
-cutoff = 0.5
+cutoff = 0.01

--- a/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
@@ -66,3 +66,5 @@ log_to_file = false
 plot_moving_average = true
 # How many consecutive data points get averaged
 range_moving_average = 20
+# cuts off data at sim_total_block_number * cutoff
+cutoff = 0.8

--- a/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_rate/config.toml
@@ -30,7 +30,7 @@ target_tps = 100.0
 # Must be greater than or equal to 0
 zipf_parameter = 1.0
 # Ratio of transactions that will be CATs
-ratio_cats = 0.1
+ratio_cats = 0.05
 # CAT lifetime in blocks
 # This is the maximum number of blocks a CAT transaction can remain pending
 cat_lifetime_blocks = 10
@@ -49,10 +49,10 @@ num_runs = 1
 # Number of simulations to run in the sweep
 num_simulations = 5
 # Step size for CAT ratio sweeps
-cat_rate_step = 0.025
+cat_rate_step = 0.05
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
-sim_total_block_number = 5000
+sim_total_block_number = 2300
 
 # Logging control for the simulator
 [logging_config]
@@ -66,4 +66,4 @@ plot_moving_average = true
 # How many consecutive data points get averaged
 range_moving_average = 20
 # cuts off data at sim_total_block_number * cutoff
-cutoff = 0.8
+cutoff = 0.5

--- a/simulator/src/scenarios/sim_sweep_cat_rate/plot_paper.py
+++ b/simulator/src/scenarios/sim_sweep_cat_rate/plot_paper.py
@@ -447,16 +447,22 @@ def plot_cat_success_percentage_violin_paper(data: Dict[str, Any], param_name: s
                     percentage = (success_at_height / total) * 100
                     percentages.append(percentage)
             
+            # Discard the first 20% of data points for violin plot
             if percentages:
-                violin_data.append(percentages)
-                labels.append(f'{param_value:.3f}')
+                num_points = len(percentages)
+                discard_count = int(num_points * 0.2)  # 20% of data points
+                filtered_percentages = percentages[discard_count:]
+                
+                if filtered_percentages:  # Only add if we have data after filtering
+                    violin_data.append(filtered_percentages)
+                    labels.append(f'{param_value:.3f}')
         
         if not violin_data:
             print("Warning: No data available for violin plot")
             return
         
         # Create violin plot
-        plt.figure(figsize=(12, 8))
+        plt.figure(figsize=(10, 6))
         
         # Create violin plot
         violin_parts = plt.violinplot(violin_data, positions=range(len(violin_data)), showmeans=True)

--- a/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
@@ -45,14 +45,14 @@ allow_cat_pending_dependencies = true
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 # Number of times to run each simulation (results will be averaged)
-num_runs = 2
+num_runs = 1
 # Number of simulations to run in the sweep
 num_simulations = 4
 # Step size for chain delay sweeps
 chain_delay_step = 0.5
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
-sim_total_block_number = 2300
+sim_total_block_number = 1000
 
 # Logging control for the simulator
 [logging_config]
@@ -66,4 +66,4 @@ plot_moving_average = true
 # How many consecutive data points get averaged
 range_moving_average = 10
 # cuts off data at sim_total_block_number * cutoff
-cutoff = 0.5
+cutoff = 0.2

--- a/simulator/src/scenarios/sweep_runner.rs
+++ b/simulator/src/scenarios/sweep_runner.rs
@@ -166,8 +166,8 @@ impl<T: std::fmt::Debug + Clone> SweepRunner<T> {
         // Log sweep start
         self.log_sweep_start(&sweep_config);
 
-        // Display sweep name before progress bar
-        println!("Running Sweep: {}", self.sweep_name);
+        // Display parameter values before progress bar
+        println!("Parameter values to test: {:?}", self.parameter_values);
 
         // Create progress bar for sweep
         let progress_bar = self.create_progress_bar(sweep_config.get_num_simulations());


### PR DESCRIPTION
# [HIG] Fix CAT timeout handling and counter management

## Summary

This PR addresses an issue in the Hyper-IG node where **timed-out CAT transactions** were not properly removed from the pending set and counters, leading to incorrect state tracking.  

Key changes:

- **Timeout detection and cleanup**:
  - Reworked `check_cat_timeouts` to iterate over all pending CATs and ensure any that exceed their max lifetime are:
    - Marked as `Failure`
    - Removed from `pending_transactions`
    - Cleared from all dependency tracking maps
  - Added consistent removal from `cat_max_lifetime`, `cat_proposed_statuses`, and key dependency structures.

- **Counter accuracy improvements**:
  - Ensured that pending, resolving, and postponed counters remain consistent after timeouts.
  - Added missing transition handling (`postponed -> resolving`) when postponed CATs are reprocessed.

- **Prevented duplicate processing**:
  - Added checks to skip reprocessing transactions that already reached a final status (`Success` or `Failure`).

- **Improved test coverage**:
  - Added `test_cat_timeout_counter_management` to validate:
    - Pending CAT count decreases after timeout
    - Failure count increases correctly
    - Timed-out CATs are removed from all state maps
  - Added `test_cat_accumulation_management` to ensure no unbounded accumulation of pending CATs.
  - Added `test_postponed_to_resolving_transition` to verify detailed counters update correctly on reprocessing.

- **Refactoring**:
  - Unified CAT dependency checks (regular vs CAT transactions).
  - Renamed and clarified methods for better semantics (`transition_count_postponed_to_resolving`).

## Motivation

Previously, timed-out CATs could stay indefinitely in the pending set and skew success/failure counters. This caused inaccurate metrics and could block dependent transactions indefinitely. With this fix:

- Timed-out CATs are fully cleaned up
- Counters reflect the actual system state
- Dependent transactions can be reprocessed as expected

## Validation

- Verified all unit tests and new counter management tests pass (`cargo test`).
- Ran simulations to confirm that:
  - CAT counts match expected values over time
  - pending CAT accumulation no longer grows unbounded 
  - Dependent transactions transition correctly after timeouts or reprocessing