### PR TITLE
[sim] Add Constant CAT number Sweep Feature

### DIFF
--- a/simulator/src/config.rs
+++ b/simulator/src/config.rs
@@ -145,6 +145,9 @@ pub struct SimulationConfig {
     /// Reference TPS for scaling (for block interval all scaled sweeps)
     #[serde(default)]
     pub reference_tps: Option<f64>,
+    /// Multiplier for target TPB per simulation step (for CAT ratio with constant CATs per block sweeps)
+    #[serde(default)]
+    pub target_tpb_multiplier_per_step: Option<f64>,
 }
 
 impl Default for SimulationConfig {
@@ -161,6 +164,7 @@ impl Default for SimulationConfig {
             block_number_step: None,
             reference_chain_delay_duration: None,
             reference_tps: None,
+            target_tpb_multiplier_per_step: None,
             sim_total_block_number: 1000, // Default value for sim_total_block_number
         }
     }

--- a/simulator/src/interface.rs
+++ b/simulator/src/interface.rs
@@ -18,6 +18,8 @@ pub enum SimulationType {
     Simple,
     /// CAT ratio parameter sweep
     SweepCatRatio,
+    /// CAT ratio with constant CATs per block sweep
+    SweepCatRatioConstantCatsPerBlock,
     /// CAT pending dependencies sweep
     SweepCatPendingDependencies,
     /// Block interval sweep with all scaled (TPS scaled to maintain constant txs per block)
@@ -58,13 +60,14 @@ impl SimulationType {
             "5" => Some(SimulationType::SweepCatLifetime),
             "6" => Some(SimulationType::SweepCatPendingDependencies),
             "7" => Some(SimulationType::SweepCatRatio),
-            "8" => Some(SimulationType::SweepChainDelay),
-            "9" => Some(SimulationType::SweepTotalBlockNumber),
-            "10" => Some(SimulationType::SweepZipf),
-            "11" => Some(SimulationType::RunAllTests),
-            "12" => Some(SimulationType::RunMissingTests),
-            "13" => Some(SimulationType::RunAllPlots),
-            "14" => Some(SimulationType::ToggleDebug),
+            "8" => Some(SimulationType::SweepCatRatioConstantCatsPerBlock),
+            "9" => Some(SimulationType::SweepChainDelay),
+            "10" => Some(SimulationType::SweepTotalBlockNumber),
+            "11" => Some(SimulationType::SweepZipf),
+            "12" => Some(SimulationType::RunAllTests),
+            "13" => Some(SimulationType::RunMissingTests),
+            "14" => Some(SimulationType::RunAllPlots),
+            "15" => Some(SimulationType::ToggleDebug),
             "0" => Some(SimulationType::Exit),
             _ => None,
         }
@@ -91,7 +94,7 @@ impl SimulatorInterface {
     /// Returns the menu text for available simulation types
     pub fn get_menu_text(&self) -> String {
         let debug_status = if self.debug_mode { "ON" } else { "OFF" };
-        format!("Available simulation types:\n  1. Simple simulation\n  ------------------------\n  2. Sweep Block Interval (All Scaled)\n  3. Sweep Block Interval (Constant Block Delay)\n  4. Sweep Block Interval (Constant Time Delay)\n  5. Sweep CAT lifetime\n  6. Sweep CAT Pending Dependencies\n  7. Sweep CAT ratio\n  8. Sweep Chain Delay\n  9. Sweep Total Block Number\n 10. Sweep Zipf distribution\n  ------------------------\n 11. Run All Tests\n 12. Run Missing Tests Only\n 13. Rerun All Plots Only\n 14. Toggle Debug Mode (currently {})\n  0. Exit", debug_status)
+        format!("Available simulation types:\n  1. Simple simulation\n  ------------------------\n  2. Sweep Block Interval (All Scaled)\n  3. Sweep Block Interval (Constant Block Delay)\n  4. Sweep Block Interval (Constant Time Delay)\n  5. Sweep CAT lifetime\n  6. Sweep CAT Pending Dependencies\n  7. Sweep CAT ratio\n  8. Sweep CAT ratio (constant CATs per block)\n  9. Sweep Chain Delay\n 10. Sweep Total Block Number\n 11. Sweep Zipf distribution\n  ------------------------\n 12. Run All Tests\n 13. Run Missing Tests Only\n 14. Rerun All Plots Only\n 15. Toggle Debug Mode (currently {})\n  0. Exit", debug_status)
     }
 
     /// Displays the simulator menu
@@ -127,6 +130,7 @@ impl SimulatorInterface {
         let data_path = match simulation_type {
             "simple" => "simulator/results/sim_simple/data",
             "sweep_cat_ratio" => "simulator/results/sim_sweep_cat_ratio/data",
+            "sweep_cat_ratio_constant_cats_per_block" => "simulator/results/sim_sweep_cat_ratio_constant_cats_per_block/data",
             "sweep_cat_pending_dependencies" => "simulator/results/sim_sweep_cat_pending_dependencies/data",
             "sweep_block_interval_constant_time_delay" => "simulator/results/sim_sweep_block_interval_constant_time_delay/data",
             "sweep_block_interval_constant_block_delay" => "simulator/results/sim_sweep_block_interval_constant_block_delay/data",
@@ -146,6 +150,7 @@ impl SimulatorInterface {
         let simulation_types = vec![
             ("simple", "Simple Simulation"),
             ("sweep_cat_ratio", "CAT Ratio Sweep"),
+            ("sweep_cat_ratio_constant_cats_per_block", "CAT Ratio with Constant CATs per Block Sweep"),
             ("sweep_cat_pending_dependencies", "CAT Pending Dependencies Sweep"),
             ("sweep_block_interval_constant_time_delay", "Block Interval (Constant Time Delay) Sweep"),
             ("sweep_block_interval_constant_block_delay", "Block Interval (Constant Block Delay) Sweep"),
@@ -184,6 +189,7 @@ impl SimulatorInterface {
             let simulation_type = match sim_type {
                 "simple" => SimulationType::Simple,
                 "sweep_cat_ratio" => SimulationType::SweepCatRatio,
+                "sweep_cat_ratio_constant_cats_per_block" => SimulationType::SweepCatRatioConstantCatsPerBlock,
                 "sweep_cat_pending_dependencies" => SimulationType::SweepCatPendingDependencies,
                 "sweep_block_interval_constant_time_delay" => SimulationType::SweepBlockIntervalConstantTimeDelay,
                 "sweep_block_interval_constant_block_delay" => SimulationType::SweepBlockIntervalConstantBlockDelay,
@@ -230,6 +236,7 @@ impl SimulatorInterface {
             "simple" => "simulator/src/scenarios/sim_simple/plot_results.py",
 
             "sweep_cat_ratio" => "simulator/src/scenarios/sim_sweep_cat_ratio/plot_results.py",
+            "sweep_cat_ratio_constant_cats_per_block" => "simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_results.py",
             "sweep_cat_pending_dependencies" => "simulator/src/scenarios/sim_sweep_cat_pending_dependencies/plot_results.py",
             "sweep_block_interval_constant_time_delay" => "simulator/src/scenarios/sim_sweep_block_interval_constant_time_delay/plot_results.py",
             "sweep_block_interval_constant_block_delay" => "simulator/src/scenarios/sim_sweep_block_interval_constant_block_delay/plot_results.py",
@@ -299,6 +306,7 @@ impl SimulatorInterface {
                         SimulationType::SweepCatLifetime |
                         SimulationType::SweepCatPendingDependencies |
                         SimulationType::SweepCatRatio |
+                        SimulationType::SweepCatRatioConstantCatsPerBlock |
                         SimulationType::SweepChainDelay |
                         SimulationType::SweepTotalBlockNumber |
                         SimulationType::SweepZipf
@@ -340,6 +348,7 @@ impl SimulatorInterface {
                                             SimulationType::SweepCatLifetime => "sweep_cat_lifetime",
                                             SimulationType::SweepCatPendingDependencies => "sweep_cat_pending_dependencies",
                                             SimulationType::SweepCatRatio => "sweep_cat_ratio",
+                                            SimulationType::SweepCatRatioConstantCatsPerBlock => "sweep_cat_ratio_constant_cats_per_block",
                                             SimulationType::SweepChainDelay => "sweep_chain_delay",
                                             SimulationType::SweepTotalBlockNumber => "sweep_total_block_number",
                                             SimulationType::SweepZipf => "sweep_zipf",

--- a/simulator/src/interface.rs
+++ b/simulator/src/interface.rs
@@ -374,6 +374,7 @@ impl SimulatorInterface {
                                     SimulationType::SweepCatLifetime => "sweep_cat_lifetime",
                                     SimulationType::SweepCatPendingDependencies => "sweep_cat_pending_dependencies",
                                     SimulationType::SweepCatRatio => "sweep_cat_ratio",
+                                    SimulationType::SweepCatRatioConstantCatsPerBlock => "sweep_cat_ratio_constant_cats_per_block",
                                     SimulationType::SweepChainDelay => "sweep_chain_delay",
                                     SimulationType::SweepTotalBlockNumber => "sweep_total_block_number",
                                     SimulationType::SweepZipf => "sweep_zipf",

--- a/simulator/src/scenarios/mod.rs
+++ b/simulator/src/scenarios/mod.rs
@@ -1,5 +1,6 @@
 pub mod sim_simple;
 pub mod sim_sweep_cat_ratio;
+pub mod sim_sweep_cat_ratio_constant_cats_per_block;
 pub mod sim_sweep_chain_delay;
 pub mod sim_sweep_total_block_number;
 pub mod sim_sweep_zipf;

--- a/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
@@ -34,7 +34,7 @@ zipf_parameter = 1.0
 ratio_cats = 0.1
 # CAT lifetime in blocks
 # This is the maximum number of blocks a CAT transaction can remain pending
-cat_lifetime_blocks = 6
+cat_lifetime_blocks = 5
 # Whether to allow CAT transactions to depend on locked keys
 # When false, CATs are rejected if they depend on locked keys
 # When true, CATs are allowed to depend on locked keys (current behavior)
@@ -50,10 +50,10 @@ num_runs = 1
 # Number of simulations to run in the sweep
 num_simulations = 4
 # Step size for CAT lifetime sweeps
-cat_lifetime_step = 4
+cat_lifetime_step = 5
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
-sim_total_block_number = 500
+sim_total_block_number = 400
 
 # Logging control for the simulator
 [logging_config]
@@ -67,4 +67,4 @@ plot_moving_average = true
 # How many consecutive data points get averaged
 range_moving_average = 10
 # cuts off data at sim_total_block_number * cutoff
-cutoff = 0.5
+cutoff = 0.1

--- a/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/README.md
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/README.md
@@ -1,0 +1,12 @@
+# CAT Ratio with Constant CATs per Block Sweep
+
+This sweep explores how different target TPB values affect system performance while maintaining a constant number of CATs per block.
+
+## Concept
+
+The CAT ratio is calculated as:
+```
+cat_ratio = constant_cats_per_block / target_tpb
+```
+
+This ensures that regardless of target TPB, the same number of CATs are generated per block, allowing us to isolate the effect of transaction rate from the effect of CAT frequency.

--- a/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/config.toml
@@ -1,0 +1,73 @@
+# Sweep CAT Ratio with Constant CATs per Block Simulation Configuration
+
+# Network parameters
+[network_config]
+# the number of chains to simulate
+num_chains = 2
+# Delay in blocks for each chain
+# The order of delays corresponds to the chain order (chain-1, chain-2, etc.)
+chain_delays = [0.0, 5.0]  # chain-1 has first value blocks delay, chain-2 has second value blocks delay
+# Block interval in seconds - this will be varied in the sweep
+block_interval = 0.1
+
+# Account parameters
+[account_config]
+# Initial balance for each account in the simulation
+# This is the amount of tokens each account starts with
+initial_balance = 9999
+# Number of accounts to create in the simulation
+# These accounts will be used to send transactions between
+num_accounts = 1000
+
+# Transaction parameters
+[transaction_config]
+# Target transactions per block to maintain during simulation
+# The simulator will try to maintain this rate by adjusting delays
+# This is the reference value (20.0) - will be varied in sweep
+target_tpb = 20.0
+# Zipf distribution parameter for account selection
+# Higher values (e.g., 1.5) make the distribution more skewed
+# Lower values (e.g., 0.5) make the distribution more uniform
+# Must be greater than or equal to 0
+zipf_parameter = 1.0
+# Ratio of transactions that will be CATs
+# This is the reference value (0.1) - will be calculated for each sweep
+# Reference gives 20.0 * 0.1 = 2 CATs per block
+ratio_cats = 0.1
+# CAT lifetime in blocks
+# This is the maximum number of blocks a CAT transaction can remain pending
+cat_lifetime_blocks = 10
+# Whether to allow CAT transactions to depend on locked keys
+# When false, CATs are rejected if they depend on locked keys
+# When true, CATs are allowed to depend on locked keys (current behavior)
+allow_cat_pending_dependencies = true
+
+# Simulation execution parameters
+[simulation_config]
+# Number of blocks to wait before starting transaction submission
+# This ensures the system is fully initialized and stable
+initialization_wait_blocks = 10
+# Number of times to run each simulation (results will be averaged)
+num_runs = 10
+# Number of simulations to run in the sweep
+num_simulations = 5
+# Multiplier for target TPB per simulation step
+# Values will be calculated as: base_tpb * (multiplier ^ step)
+target_tpb_multiplier_per_step = 3.16227766017 # sqrt(10)
+# Total number of blocks to simulate
+# The simulation will run until this many blocks have been produced
+sim_total_block_number = 400
+
+# Logging control for the simulator
+[logging_config]
+# Whether to write logs to a file (true = write to file, false = no file logging)
+log_to_file = false
+
+# Plot configuration
+[plot_config]
+# Turn on to plot the moving average
+plot_moving_average = true
+# How many consecutive data points get averaged
+range_moving_average = 20
+# cuts off data at sim_total_block_number * cutoff
+cutoff = 0.01 

--- a/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/mod.rs
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/mod.rs
@@ -1,0 +1,1 @@
+pub mod simulation; 

--- a/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_paper.py
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_paper.py
@@ -2,16 +2,342 @@
 """
 Paper-specific plotting script for Cat Ratio Constant Cats Per Block Sweep Simulation
 
-This script is a placeholder for paper-specific plots.
-Currently no plots are implemented for this sweep.
+This script generates plots specifically designed for paper publication,
+including CAT success percentage violin plots.
 """
 
 import sys
 import os
+import json
+import matplotlib.pyplot as plt
+import numpy as np
+from typing import Dict, List, Tuple, Any
+
+# Add the scripts directory to the Python path to import plot_utils
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from plot_utils import create_color_gradient, extract_parameter_value, create_parameter_label, create_sweep_title, trim_time_series_data
+from plot_utils_percentage import plot_transaction_percentage
+
+# Check if debug mode is enabled
+DEBUG_MODE = os.environ.get('DEBUG_MODE', '0') == '1'
+
+def load_individual_run_data(results_dir: str, param_name: str) -> List[Dict[str, Any]]:
+    """
+    Load individual run data from data/sim_x/run_y/data/ directories.
+    
+    Returns a list of run data dictionaries, each containing:
+    - param_name: parameter value
+    - sim_index: simulation index
+    - run_index: run index
+    - chain_1_cat_success: success data
+    - chain_1_cat_failure: failure data
+    """
+    individual_runs = []
+    
+    # Load metadata to get parameter values
+    metadata_path = f'{results_dir}/data/metadata.json'
+    if not os.path.exists(metadata_path):
+        print(f"Warning: No metadata found at {metadata_path}")
+        return individual_runs
+    
+    with open(metadata_path, 'r') as f:
+        metadata = json.load(f)
+    
+    param_values = metadata['parameter_values']
+    num_simulations = len(param_values)
+    
+    # For each simulation
+    for sim_index in range(num_simulations):
+        param_value = param_values[sim_index]
+        sim_dir = f'{results_dir}/data/sim_{sim_index}'
+        
+        # Find all run directories
+        if not os.path.exists(sim_dir):
+            continue
+            
+        run_dirs = [d for d in os.listdir(sim_dir) if d.startswith('run_') and d != 'run_average']
+        
+        # For each run
+        for run_dir in run_dirs:
+            run_index = int(run_dir.split('_')[1])
+            run_data_dir = f'{sim_dir}/{run_dir}/data'
+            
+            if not os.path.exists(run_data_dir):
+                continue
+            
+            # Load CAT success and failure data
+            cat_success_file = f'{run_data_dir}/cat_success_transactions_chain_1.json'
+            cat_failure_file = f'{run_data_dir}/cat_failure_transactions_chain_1.json'
+            
+            run_data = {
+                param_name: param_value,
+                'sim_index': sim_index,
+                'run_index': run_index
+            }
+            
+            # Load success data
+            if os.path.exists(cat_success_file):
+                with open(cat_success_file, 'r') as f:
+                    success_data = json.load(f)
+                    if 'chain_1_cat_success' in success_data:
+                        # Convert to list of tuples for plotting
+                        time_series_data = []
+                        for entry in success_data['chain_1_cat_success']:
+                            time_series_data.append((entry['height'], entry['count']))
+                        run_data['chain_1_cat_success'] = time_series_data
+            
+            # Load failure data
+            if os.path.exists(cat_failure_file):
+                with open(cat_failure_file, 'r') as f:
+                    failure_data = json.load(f)
+                    if 'chain_1_cat_failure' in failure_data:
+                        # Convert to list of tuples for plotting
+                        time_series_data = []
+                        for entry in failure_data['chain_1_cat_failure']:
+                            time_series_data.append((entry['height'], entry['count']))
+                        run_data['chain_1_cat_failure'] = time_series_data
+            
+            individual_runs.append(run_data)
+    
+    return individual_runs
+
+
+# Stub functions for other plots that the system expects
+def plot_cat_success_percentage_with_overlay(data: Dict[str, Any], param_name: str, results_dir: str, sweep_type: str) -> None:
+    """Stub function - not implemented for this sweep."""
+    pass
+
+def plot_cat_success_percentage_violin_paper(data: Dict[str, Any], param_name: str, results_dir: str, sweep_type: str, plot_config: Dict[str, Any]) -> None:
+    """Stub function - not implemented for this sweep."""
+    pass
+
+def plot_tx_pending_cat_postponed_violin(data: Dict[str, Any], param_name: str, results_dir: str, sweep_type: str, plot_config: Dict[str, Any]) -> None:
+    """Stub function - not implemented for this sweep."""
+    pass
+
+def plot_tx_pending_cat_resolving_violin(data: Dict[str, Any], param_name: str, results_dir: str, sweep_type: str, plot_config: Dict[str, Any]) -> None:
+    """Stub function - not implemented for this sweep."""
+    pass
+
+def plot_tx_pending_regular_violin(data: Dict[str, Any], param_name: str, results_dir: str, sweep_type: str, plot_config: Dict[str, Any]) -> None:
+    """Stub function - not implemented for this sweep."""
+    pass
+
+
+def plot_cat_success_percentage_violin(data: Dict[str, Any], param_name: str, results_dir: str, sweep_type: str, plot_config: Dict[str, Any]) -> None:
+    """
+    Plot CAT success percentage violin plot for paper publication.
+    
+    This creates a violin plot showing the distribution of CAT success percentages
+    for each target TPB value, using the final values from each run.
+    """
+    try:
+        individual_results = data['individual_results']
+        
+        # Extract parameter values and results
+        param_values = []
+        results = []
+        
+        for result in individual_results:
+            param_value = extract_parameter_value(result, param_name)
+            param_values.append(param_value)
+            results.append(result)
+        
+        # Load metadata to get number of runs
+        metadata_path = f'{results_dir}/data/metadata.json'
+        if not os.path.exists(metadata_path):
+            print(f"Warning: No metadata found at {metadata_path}")
+            return
+        
+        with open(metadata_path, 'r') as f:
+            metadata = json.load(f)
+        
+        num_runs = metadata['num_runs']
+        num_simulations = len(param_values)
+        
+        # Collect percentage data for each simulation
+        violin_data = []
+        labels = []
+        
+        for sim_index in range(num_simulations):
+            param_value = param_values[sim_index]
+            sim_dir = f'{results_dir}/data/sim_{sim_index}'
+            
+            # Find all run directories for this simulation
+            if not os.path.exists(sim_dir):
+                continue
+                
+            run_dirs = [d for d in os.listdir(sim_dir) if d.startswith('run_') and d != 'run_average']
+            
+            # Calculate final CAT success percentage for each run
+            final_percentages = []
+            
+            for run_dir in run_dirs:
+                run_data_dir = f'{sim_dir}/{run_dir}/data'
+                
+                if not os.path.exists(run_data_dir):
+                    continue
+                
+                # Load CAT success and failure data
+                cat_success_file = f'{run_data_dir}/cat_success_transactions_chain_1.json'
+                cat_failure_file = f'{run_data_dir}/cat_failure_transactions_chain_1.json'
+                
+                # Load success data
+                cat_success_data = []
+                if os.path.exists(cat_success_file):
+                    with open(cat_success_file, 'r') as f:
+                        success_data = json.load(f)
+                        if 'chain_1_cat_success' in success_data:
+                            cat_success_data = [(entry['height'], entry['count']) for entry in success_data['chain_1_cat_success']]
+                
+                # Load failure data
+                cat_failure_data = []
+                if os.path.exists(cat_failure_file):
+                    with open(cat_failure_file, 'r') as f:
+                        failure_data = json.load(f)
+                        if 'chain_1_cat_failure' in failure_data:
+                            cat_failure_data = [(entry['height'], entry['count']) for entry in failure_data['chain_1_cat_failure']]
+                
+                if not cat_success_data and not cat_failure_data:
+                    continue
+                
+                # Calculate percentage over time using point-in-time calculations
+                percentages = []
+                
+                # Convert to height->count mapping
+                cat_success_by_height = {entry[0]: entry[1] for entry in cat_success_data}
+                cat_failure_by_height = {entry[0]: entry[1] for entry in cat_failure_data}
+                
+                # Get all unique heights
+                all_heights = set()
+                for height, _ in cat_success_data:
+                    all_heights.add(height)
+                for height, _ in cat_failure_data:
+                    all_heights.add(height)
+                
+                # Calculate percentage at each height
+                for height in sorted(all_heights):
+                    success_at_height = cat_success_by_height.get(height, 0)
+                    failure_at_height = cat_failure_by_height.get(height, 0)
+                    
+                    # Calculate percentage of success vs total (success + failure)
+                    total = success_at_height + failure_at_height
+                    if total > 0:
+                        percentage = (success_at_height / total) * 100
+                        percentages.append(percentage)
+                
+                # Get the final percentage (last value in the vector)
+                if percentages:
+                    final_percentage = percentages[-1]
+                    final_percentages.append(final_percentage)
+            
+            # Add the final percentages for this simulation to violin data
+            if final_percentages:
+                violin_data.append(final_percentages)
+                labels.append(f'{param_value:.3f}')
+    
+        if not violin_data:
+            print("Warning: No data available for violin plot")
+            return
+        
+        # Save violin plot data to data/paper/ folder
+        paper_data_dir = f'{results_dir}/data/paper'
+        os.makedirs(paper_data_dir, exist_ok=True)
+        
+        # Create data structure for saving
+        violin_plot_data = {
+            'parameter_name': param_name,
+            'sweep_type': sweep_type,
+            'num_simulations': len(violin_data),
+            'num_runs': num_runs,
+            'data': []
+        }
+        
+        for i, (percentages, label) in enumerate(zip(violin_data, labels)):
+            violin_plot_data['data'].append({
+                'simulation_index': i,
+                'parameter_value': float(label),
+                'final_percentages': percentages,
+                'mean_percentage': np.mean(percentages),
+                'std_percentage': np.std(percentages),
+                'min_percentage': np.min(percentages),
+                'max_percentage': np.max(percentages)
+            })
+        
+        # Save the data
+        violin_data_file = f'{paper_data_dir}/cat_success_percentage_violin.json'
+        with open(violin_data_file, 'w') as f:
+            json.dump(violin_plot_data, f, indent=2)
+        
+        print(f"Saved violin plot data to: {violin_data_file}")
+        
+        # Create violin plot
+        violin_parts = plt.violinplot(violin_data, positions=range(len(violin_data)), showmeans=True)
+        
+        # Customize violin plot appearance
+        violin_parts['cmeans'].set_color('red')
+        violin_parts['cmeans'].set_linewidth(2)
+        violin_parts['cbars'].set_color('black')
+        violin_parts['cmins'].set_color('black')
+        violin_parts['cmaxes'].set_color('black')
+        
+        # Set x-axis labels
+        plt.xticks(range(len(violin_data)), labels)
+        
+        # Customize plot
+        plt.xlabel('Target TPB')
+        plt.ylabel('CAT Success Percentage (%)')
+        plt.title(f'CAT Success Percentage Distribution by Target TPB - {create_sweep_title(param_name, sweep_type)}')
+        plt.grid(True, alpha=0.3)
+        plt.tight_layout()
+        
+        # Create the paper directory and plot
+        paper_dir = f'{results_dir}/figs/paper'
+        os.makedirs(paper_dir, exist_ok=True)
+        plt.savefig(f'{paper_dir}/cat_success_percentage_violin.png',
+                    dpi=300, bbox_inches='tight')
+        plt.close()
+        
+        print(f"Generated violin plot: cat_success_percentage_violin.png")
+        
+    except Exception as e:
+        print(f"Error generating violin plot: {e}")
+        import traceback
+        traceback.print_exc()
+
 
 def main():
-    """Main function for paper-specific plots for cat ratio constant cats per block sweep simulation."""
-    print("No paper plots implemented for this sweep yet.")
+    """Main function to generate paper-specific plots for cat ratio constant cats per block sweep simulation."""
+    # Configuration for this specific sweep
+    param_name = 'target_tpb'
+    results_dir = '../../../results/sim_sweep_cat_ratio_constant_cats_per_block'
+    sweep_type = 'CAT Ratio Constant Cats Per Block'
+    
+    # Load sweep data directly from run_average folders
+    try:
+        # Import the data loading function from plot_utils
+        from plot_utils import load_sweep_data_from_run_average
+        
+        # Load data directly from run_average folders
+        results_dir_name = results_dir.split('/')[-1]  # Extract 'sim_sweep_cat_ratio_constant_cats_per_block'
+        data = load_sweep_data_from_run_average(results_dir_name, '../../../results')
+        
+        # Check if we have any data to plot
+        if not data.get('individual_results'):
+            print(f"No data found for {sweep_type} simulation. Skipping paper plot generation.")
+            return
+        
+        # Load plot configuration for cutoff settings
+        from plot_utils import load_plot_config
+        plot_config = load_plot_config(results_dir)
+        
+        # Generate paper-specific plots
+        plot_cat_success_percentage_violin(data, param_name, results_dir, sweep_type, plot_config)
+        
+    except Exception as e:
+        print(f"Error in main: {e}")
+        import traceback
+        traceback.print_exc()
 
 if __name__ == "__main__":
     main() 

--- a/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_paper.py
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_paper.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+Paper-specific plotting script for Cat Ratio Constant Cats Per Block Sweep Simulation
+
+This script is a placeholder for paper-specific plots.
+Currently no plots are implemented for this sweep.
+"""
+
+import sys
+import os
+
+def main():
+    """Main function for paper-specific plots for cat ratio constant cats per block sweep simulation."""
+    print("No paper plots implemented for this sweep yet.")
+
+if __name__ == "__main__":
+    main() 

--- a/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_results.py
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_results.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+Plotting script for CAT Ratio with Constant CATs per Block Sweep Simulation
+
+This script generates plots for the CAT ratio with constant CATs per block sweep using the generic
+plotting utilities to eliminate code duplication.
+"""
+
+import sys
+import os
+
+# Add the scripts directory to the Python path to import plot_utils
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+from plot_utils import generate_all_plots
+
+def main():
+    """Main function to generate plots for CAT ratio with constant CATs per block sweep simulation."""
+    import sys
+    import os
+    
+    # Check if debug mode is enabled
+    debug_mode = os.environ.get('DEBUG_MODE', '0') == '1'
+    
+    if debug_mode:
+        print("DEBUG: CAT ratio constant CATs per block plot_results.py main() called", flush=True)
+        sys.stderr.write("STDERR DEBUG: CAT ratio constant CATs per block plot_results.py main() called\n")
+        sys.stderr.flush()
+    
+    # Configuration for this specific sweep
+    param_name = 'target_tpb'
+    results_dir = 'simulator/results/sim_sweep_cat_ratio_constant_cats_per_block'
+    sweep_type = 'CAT Ratio with Constant CATs per Block'
+    
+    if debug_mode:
+        print(f"DEBUG: About to call generate_all_plots with results_dir={results_dir}, param_name={param_name}, sweep_type={sweep_type}", flush=True)
+        sys.stderr.write(f"STDERR DEBUG: About to call generate_all_plots with results_dir={results_dir}, param_name={param_name}, sweep_type={sweep_type}\n")
+        sys.stderr.flush()
+    
+    # Generate all plots using the generic utility
+    # Data flow: run_average folders -> sweep_results_averaged.json -> plots
+    generate_all_plots(results_dir, param_name, sweep_type)
+    
+    if debug_mode:
+        print("DEBUG: generate_all_plots call completed", flush=True)
+        sys.stderr.write("STDERR DEBUG: generate_all_plots call completed\n")
+        sys.stderr.flush()
+
+if __name__ == "__main__":
+    main() 

--- a/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/simulation.rs
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/simulation.rs
@@ -1,0 +1,170 @@
+use crate::scenarios::sweep_runner::{SweepRunner, create_modified_config};
+use crate::define_sweep_config;
+use crate::config::ValidateConfig;
+use crate::scenarios::utils::run_simulation_with_plotting;
+use serde::Deserialize;
+
+// ------------------------------------------------------------------------------------------------
+// Sweep-Specific Parameter Struct
+// ------------------------------------------------------------------------------------------------
+
+/// Parameters specific to the CAT ratio with constant CATs per block sweep simulation.
+/// 
+/// This struct defines the parameters used to control the sweep where target_tpb
+/// is varied and cat_ratio is calculated to maintain constant CATs per block.
+#[derive(Debug, Deserialize, Clone)]
+pub struct CatRatioConstantCatsPerBlockSweepParameters {
+    /// Total number of simulation runs in the sweep (determines how many parameter values to test)
+    pub num_simulations: usize,
+    /// Multiplier for target TPB per simulation step
+    pub target_tpb_multiplier_per_step: f64,
+}
+
+// ------------------------------------------------------------------------------------------------
+// Sweep Configuration
+// ------------------------------------------------------------------------------------------------
+
+// Defines the sweep configuration for CAT ratio with constant CATs per block simulations.
+// 
+// This macro generates a complete sweep configuration setup including:
+// - A config struct with standard fields (network_config, account_config, transaction_config, sweep)
+// - Standard validation logic for common fields
+// - SweepConfigTrait implementation for integration with the generic SweepRunner
+// - A load_config() function that reads and validates the TOML configuration file
+define_sweep_config!(
+    "sim_sweep_cat_ratio_constant_cats_per_block",
+    SweepCatRatioConstantCatsPerBlockConfig,
+    validate_sweep_specific = |self_: &Self| {
+        // Need target_tpb_multiplier_per_step to calculate the sequence of target TPB values to test
+        if self_.simulation_config.target_tpb_multiplier_per_step.is_none() {
+            return Err(crate::config::ConfigError::ValidationError("Target TPB multiplier per step must be specified".into()));
+        }
+        
+        let multiplier = self_.simulation_config.target_tpb_multiplier_per_step.unwrap();
+        if multiplier <= 0.0 {
+            return Err(crate::config::ConfigError::ValidationError("Target TPB multiplier per step must be positive".into()));
+        }
+        
+        Ok(())
+    }
+);
+
+// ------------------------------------------------------------------------------------------------
+// Simulation Runner
+// ------------------------------------------------------------------------------------------------
+
+/// Runs the sweep CAT ratio with constant CATs per block simulation
+/// 
+/// This simulation explores how different target TPB and CAT ratio combinations
+/// affect system performance while maintaining a constant number of CATs per block.
+/// The CATs per block is calculated as: cat_ratio × target_tpb
+/// 
+/// This ensures that regardless of the target TPB, the same number of CATs are
+/// generated per block, allowing us to isolate the effect of transaction rate
+/// from the effect of CAT frequency.
+pub async fn run_sweep_cat_ratio_constant_cats_per_block_simulation() -> Result<(), crate::config::ConfigError> {
+    // Load sweep configuration to get parameter values
+    // This reads the sweep settings from config_sweep_cat_ratio_constant_cats_per_block.toml
+    let sweep_config = load_config()?;
+    
+    // Get multiplier and number of simulations from config
+    let multiplier = sweep_config.simulation_config.target_tpb_multiplier_per_step.unwrap();
+    let num_simulations = sweep_config.simulation_config.num_simulations.unwrap();
+    
+    // Calculate target TPB values using the multiplier
+    // base_tpb * (multiplier ^ step) for each simulation
+    let base_tpb = 2.0; // Starting value
+    let mut target_tpb_values = Vec::new();
+    for step in 0..num_simulations {
+        let target_tpb = base_tpb * multiplier.powi(step as i32);
+        target_tpb_values.push(target_tpb);
+    }
+    
+    // Calculate the reference CATs per block from the base config (for verification)
+    let reference_target_tpb = sweep_config.transaction_config.target_tpb;
+    let reference_cat_ratio = sweep_config.transaction_config.ratio_cats;
+    let _constant_cats_per_block = reference_target_tpb * reference_cat_ratio; // Should be 2.0
+
+    // Create the generic sweep runner that handles all the common functionality
+    // This eliminates code duplication across different sweep types
+    let runner = SweepRunner::new(
+        "CAT Ratio with Constant CATs per Block",  // Human-readable name for logging
+        "sim_sweep_cat_ratio_constant_cats_per_block",  // Directory name for results
+        "target_tpb",                             // Parameter name for JSON output
+        target_tpb_values,                        // List of parameter values to test
+        // Function to load the sweep configuration
+        Box::new(|| {
+            load_config().map(|config| Box::new(config) as Box<dyn crate::scenarios::sweep_runner::SweepConfigTrait>)
+        }),
+        // Function to create a modified config for each simulation using the helper
+        Box::new(|sweep_config, target_tpb| {
+            // Calculate the CAT ratio to maintain constant CATs per block
+            // constant_cats_per_block = target_tpb * cat_ratio
+            // So: cat_ratio = constant_cats_per_block / target_tpb
+            let constant_cats_per_block = 2.0; // From reference config (20.0 * 0.1)
+            let cat_ratio = constant_cats_per_block / target_tpb;
+            
+            create_modified_config(sweep_config, |base_config| {
+                crate::config::Config {
+                    network_config: base_config.network_config.clone(),
+                    account_config: base_config.account_config.clone(),
+                    transaction_config: crate::config::TransactionConfig {
+                        target_tpb: target_tpb,  // This is the parameter we're varying
+                        zipf_parameter: base_config.transaction_config.zipf_parameter,
+                        ratio_cats: cat_ratio,  // Calculated to maintain constant CATs per block
+                        cat_lifetime_blocks: base_config.transaction_config.cat_lifetime_blocks,
+                        allow_cat_pending_dependencies: base_config.transaction_config.allow_cat_pending_dependencies,
+                    },
+                    simulation_config: base_config.simulation_config.clone(),
+                    logging_config: base_config.logging_config.clone(),
+                }
+            })
+        }),
+        // Function to save the combined results from all simulations
+        // Note: Data is now handled by the averaging script and plotting code
+        Box::new(|_results_dir, _all_results| {
+            Ok(())
+        }),
+    );
+
+    // Execute the sweep
+    runner.run().await
+}
+
+// ------------------------------------------------------------------------------------------------
+// Registration
+// ------------------------------------------------------------------------------------------------
+
+/// Registers this sweep simulation with the simulation registry
+/// 
+/// This function is called by the simulation registry to register this sweep
+/// so it can be selected from the main menu.
+pub fn register() -> (crate::interface::SimulationType, crate::simulation_registry::SimulationConfig) {
+    use crate::interface::SimulationType;
+    use crate::simulation_registry::SimulationConfig;
+    
+    (SimulationType::SweepCatRatioConstantCatsPerBlock, SimulationConfig {
+        name: "CAT Ratio with Constant CATs per Block Sweep",
+        run_fn: Box::new(|| Box::pin(async {
+            run_sweep_cat_ratio_constant_cats_per_block_simulation().await
+                .map_err(|e| format!("CAT ratio constant CATs per block sweep failed: {}", e))
+        })),
+        plot_script: "simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_results.py",
+    })
+}
+
+// ------------------------------------------------------------------------------------------------
+// Public Interface
+// ------------------------------------------------------------------------------------------------
+
+/// Public function to run the simulation with plotting
+/// 
+/// This is the main entry point for running this sweep simulation.
+/// It loads the configuration, runs the sweep, and generates plots.
+pub async fn run_with_plotting() -> Result<(), crate::config::ConfigError> {
+    run_simulation_with_plotting(
+        || run_sweep_cat_ratio_constant_cats_per_block_simulation(),
+        "CAT Ratio with Constant CATs per Block Sweep",
+        "simulator/src/scenarios/sim_sweep_cat_ratio_constant_cats_per_block/plot_results.py"
+    ).await
+} 

--- a/simulator/src/simulation_registry.rs
+++ b/simulator/src/simulation_registry.rs
@@ -12,6 +12,7 @@ use tokio::sync::Mutex;
 use crate::scenarios::{
     sim_simple,
     sim_sweep_cat_ratio,
+    sim_sweep_cat_ratio_constant_cats_per_block,
     sim_sweep_zipf,
     sim_sweep_chain_delay,
     sim_sweep_total_block_number,
@@ -84,6 +85,9 @@ impl SimulationRegistry {
         simulations.insert(sim_type, sim_config);
         
         let (sim_type, sim_config) = sim_sweep_cat_ratio::simulation::register();
+        simulations.insert(sim_type, sim_config);
+        
+        let (sim_type, sim_config) = sim_sweep_cat_ratio_constant_cats_per_block::simulation::register();
         simulations.insert(sim_type, sim_config);
         
         let (sim_type, sim_config) = sim_sweep_chain_delay::simulation::register();


### PR DESCRIPTION
# Add Constant CAT number Sweep Feature

## Overview

Adds a new simulation sweep that explores how different target TPB values affect system performance while maintaining a constant number of CATs per block. This isolates transaction rate effects from CAT frequency effects.

## Key Changes

### New Simulation Type
- Added `SweepCatRatioConstantCatsPerBlock` enum variant
- Updated menu and registry integration
- Added `target_tpb_multiplier_per_step` config field

### Implementation
- **Core Logic**: `cat_ratio = constant_cats_per_block / target_tpb`
- **Sweep Progression**: `target_tpb = base_tpb × (multiplier ^ step)`
- **Plotting**: Violin plots for CAT success percentage distribution
- **Data Export**: JSON format for external analysis

### Module Structure
```
sim_sweep_cat_ratio_constant_cats_per_block/
├── simulation.rs          # Core sweep logic
├── plot_results.py        # Standard plots
├── plot_paper.py         # Publication plots
├── config.toml           # Example config
└── README.md             # Documentation
```
