### PR TITLE
Hig/regular tx dependency

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -160,6 +160,7 @@ TESTS=(
 TESTS2=(
     hyper_ig::tests::dependencies::test_regular_tx_depends_on_pending_regular_tx
     hyper_ig::tests::dependencies::test_key_last_locked_by_tx_length_tracking
+    hyper_ig::tests::dependencies::test_regular_tx_blocks_cat_transitively
 )
 
 # Check if arguments are provided

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -158,8 +158,7 @@ TESTS=(
 )
 
 TESTS2=(
-    hyper_ig::tests::counter_management::test_postponed_to_resolving_transition
-    hyper_ig::tests::counter_management::test_regular_transaction_timing_metrics
+    hyper_ig::tests::dependencies::test_regular_tx_depends_on_pending_regular_tx
 )
 
 # Check if arguments are provided

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -158,9 +158,8 @@ TESTS=(
 )
 
 TESTS2=(
-    hyper_ig::tests::dependencies::test_regular_tx_depends_on_pending_regular_tx
-    hyper_ig::tests::dependencies::test_key_last_locked_by_tx_length_tracking
-    hyper_ig::tests::dependencies::test_regular_tx_blocks_cat_transitively
+    hyper_ig::tests::dependencies::test_regular_tx_dependency_chain_resolution
+    hyper_ig::tests::counter_management::test_regular_tx_multiple_dependencies
 )
 
 # Check if arguments are provided

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -159,6 +159,7 @@ TESTS=(
 
 TESTS2=(
     hyper_ig::tests::dependencies::test_regular_tx_depends_on_pending_regular_tx
+    hyper_ig::tests::dependencies::test_key_last_locked_by_tx_length_tracking
 )
 
 # Check if arguments are provided

--- a/simulator/src/scenarios/plot_manager.py
+++ b/simulator/src/scenarios/plot_manager.py
@@ -80,6 +80,10 @@ def generate_tx_plots(data, param_name, results_dir, sweep_type, plot_config):
     plot_transactions_overlay(data, param_name, 'regular_tx_max_latency', results_dir, sweep_type)
     plot_transactions_overlay(data, param_name, 'regular_tx_finalized_count', results_dir, sweep_type)
     
+    # Regular transaction timing metrics in blocks
+    plot_transactions_overlay(data, param_name, 'regular_tx_avg_latency_blocks', results_dir, sweep_type)
+    plot_transactions_overlay(data, param_name, 'regular_tx_max_latency_blocks', results_dir, sweep_type)
+    
     # Total transaction plots
     plot_total_cat_transactions(data, param_name, results_dir, sweep_type)
     plot_total_regular_transactions(data, param_name, results_dir, sweep_type)

--- a/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_lifetime/config.toml
@@ -37,7 +37,7 @@ zipf_parameter = 0.8
 ratio_cats = 0.5
 # CAT lifetime in blocks
 # This is the maximum number of blocks a CAT transaction can remain pending
-cat_lifetime_blocks = 10
+cat_lifetime_blocks = 5
 # Whether to allow CAT transactions to depend on locked keys
 # When false, CATs are rejected if they depend on locked keys
 # When true, CATs are allowed to depend on locked keys (current behavior)
@@ -51,12 +51,12 @@ initialization_wait_blocks = 10
 # Number of times to run each simulation (results will be averaged)
 num_runs = 3
 # Number of simulations to run in the sweep
-num_simulations = 2
+num_simulations = 10
 # Step size for CAT lifetime sweeps
-cat_lifetime_step = 10
+cat_lifetime_step = 5
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
-sim_total_block_number = 40
+sim_total_block_number = 200
 
 # Logging control for the simulator
 [logging_config]

--- a/simulator/src/scenarios/sim_sweep_cat_ratio/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio/config.toml
@@ -48,11 +48,11 @@ allow_cat_pending_dependencies = true
 # This ensures the system is fully initialized and stable
 initialization_wait_blocks = 10
 # Number of times to run each simulation (results will be averaged)
-num_runs = 1
+num_runs = 5
 # Number of simulations to run in the sweep
-num_simulations = 6
+num_simulations = 11
 # Step size for CAT ratio sweeps
-cat_ratio_step = 0.2
+cat_ratio_step = 0.1
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 200

--- a/simulator/src/scenarios/sim_sweep_cat_ratio/config.toml
+++ b/simulator/src/scenarios/sim_sweep_cat_ratio/config.toml
@@ -26,7 +26,7 @@ num_accounts = 10000
 [transaction_config]
 # Target transactions per block to maintain during simulation
 # The simulator will try to maintain this rate by adjusting delays
-target_tpb = 200.0
+target_tpb = 100.0
 # Zipf distribution parameter for account selection
 # Higher values (e.g., 1.5) make the distribution more skewed
 # Lower values (e.g., 0.5) make the distribution more uniform
@@ -50,12 +50,12 @@ initialization_wait_blocks = 10
 # Number of times to run each simulation (results will be averaged)
 num_runs = 1
 # Number of simulations to run in the sweep
-num_simulations = 3
+num_simulations = 6
 # Step size for CAT ratio sweeps
 cat_ratio_step = 0.2
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
-sim_total_block_number = 60
+sim_total_block_number = 200
 
 # Logging control for the simulator
 [logging_config]

--- a/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
+++ b/simulator/src/scenarios/sim_sweep_chain_delay/config.toml
@@ -26,7 +26,7 @@ num_accounts = 10000
 [transaction_config]
 # Target transactions per block to maintain during simulation
 # The simulator will try to maintain this rate by adjusting delays
-target_tpb = 200.0
+target_tpb = 100.0
 # Zipf distribution parameter for account selection
 # Higher values (e.g., 1.5) make the distribution more skewed
 # Lower values (e.g., 0.5) make the distribution more uniform
@@ -50,9 +50,9 @@ initialization_wait_blocks = 10
 # Number of times to run each simulation (results will be averaged)
 num_runs = 5
 # Number of simulations to run in the sweep
-num_simulations = 6
+num_simulations = 5
 # Step size for chain delay sweeps
-chain_delay_step = 0.2
+chain_delay_step = 0.25
 # Total number of blocks to simulate
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 100

--- a/simulator/src/scenarios/sim_sweep_tpb_constant_cats_per_block/config.toml
+++ b/simulator/src/scenarios/sim_sweep_tpb_constant_cats_per_block/config.toml
@@ -11,7 +11,7 @@ chain_delays = [0.0, 5.0]  # chain-1 has first value blocks delay, chain-2 has s
 # The relationship is: block_interval = target_tpb / 100
 # So: target_tpb=200 -> block_interval=2.0, target_tpb=100 -> block_interval=1.0
 # Note: This value is the starting point and will be scaled for each simulation step
-block_interval = 1.0
+block_interval = 0.5
 # Channel buffer size for high-performance communication
 # Larger values handle higher TPS but use more memory
 channel_buffer_size = 1000
@@ -31,7 +31,7 @@ num_accounts = 10000
 # The simulator will try to maintain this rate by adjusting delays
 # This is the starting value (200.0) - will be varied in sweep
 # Block interval will automatically scale with target_tpb: block_interval = target_tpb / 100
-target_tpb = 100.0
+target_tpb = 50.0
 # Zipf distribution parameter for account selection
 # Higher values (e.g., 1.5) make the distribution more skewed
 # Lower values (e.g., 0.5) make the distribution more uniform
@@ -39,7 +39,7 @@ target_tpb = 100.0
 zipf_parameter = 0.8
 # Ratio of transactions that will be CATs
 # This is the reference value (0.5) - will be calculated for each sweep
-ratio_cats = 0.5
+ratio_cats = 1.0
 # CAT lifetime in blocks
 # This is the maximum number of blocks a CAT transaction can remain pending
 cat_lifetime_blocks = 10
@@ -56,7 +56,7 @@ initialization_wait_blocks = 10
 # Number of times to run each simulation (results will be averaged)
 num_runs = 3
 # Number of simulations to run in the sweep
-num_simulations = 7
+num_simulations = 8
 # Multiplier for target TPB per simulation step
 # Values will be calculated as: base_tpb * (multiplier ^ step)
 # With base_tpb=100 (from target_tpb) and 7 simulations, this gives: [100, 200, 400, 800, 1600, 3200, 6400]
@@ -66,7 +66,7 @@ target_tpb_multiplier_per_step = 2 # sqrt(10)
 # The simulation will run until this many blocks have been produced
 sim_total_block_number = 100
 # Constant number of CATs per block (used instead of ratio_cats)
-constants_cats_per_block = 100
+constants_cats_per_block = 50
 
 # Logging control for the simulator
 [logging_config]

--- a/simulator/src/scenarios/sim_sweep_zipf/config.toml
+++ b/simulator/src/scenarios/sim_sweep_zipf/config.toml
@@ -20,20 +20,20 @@ channel_buffer_size = 1000
 initial_balance = 9999
 # Number of accounts to create in the simulation
 # These accounts will be used to send transactions between
-num_accounts = 100000
+num_accounts = 10000
 
 # Transaction parameters
 [transaction_config]
 # Target transactions per block to maintain during simulation
 # The simulator will try to maintain this rate by adjusting delays
-target_tpb = 200.0
+target_tpb = 100.0
 # Zipf distribution parameter for account selection
 # Higher values (e.g., 1.5) make the distribution more skewed
 # Lower values (e.g., 0.5) make the distribution more uniform
 # Must be greater than or equal to 0
 zipf_parameter = 0.8
 # Ratio of transactions that will be CATs
-ratio_cats = 0.025
+ratio_cats = 0.5
 # CAT lifetime in blocks
 # This is the maximum number of blocks a CAT transaction can remain pending
 cat_lifetime_blocks = 10

--- a/src/hyper_ig/README.md
+++ b/src/hyper_ig/README.md
@@ -197,24 +197,28 @@ The dependency system works like an onion with multiple layers:
 
 ### Key Data Structures
 
-- **`key_locked_by_tx`**: Maps keys to the transaction currently locking them
+- **`key_last_locked_by_tx`**: Maps keys to the last transaction that locked them (onion layer model)
 - **`tx_locks_keys`**: Maps transactions to the keys they lock (reverse index)
+- **`tx_locks_consumer`**: Maps transactions to the transactions that depend on them (dependency consumers)
 - **`key_causes_dependencies_for_txs`**: Maps keys to transactions waiting on them
 - **`tx_depends_on_txs`**: Maps transactions to their dependencies
 
-### TODO: Regular Transaction Dependencies
+### ✅ COMPLETED: Regular Transaction Dependencies
 
-**Current Limitation**: Regular transactions cannot depend on other regular transactions
+**Status**: Regular transactions can now depend on other regular transactions and CATs
 
-**Issues to Fix**:
-- [ ] Regular transactions that execute immediately don't participate in the dependency resolution system
-- [ ] The dependency tracking structures are not updated for regular transaction completion
+**Implemented Features**:
+- ✅ **Lock keys during pending state** (when regular transactions have dependencies)
+- ✅ **Release locks and notify dependents** when regular transactions complete
+- ✅ **Participate in the dependency resolution system** like CATs do
+- ✅ **Modified `handle_regular_transaction`** to lock keys when dependencies exist
+- ✅ **Enhanced dependency resolution** to handle regular transaction lock release
+- ✅ **Created tests** for regular transaction dependencies
+- ✅ **Tested mixed scenarios** (regular→CAT, CAT→regular, regular→regular)
 
-**Implementation Tasks**:
-- [ ] **Lock keys during pending state** (when regular transactions have dependencies)
-- [ ] **Release locks and notify dependents** when regular transactions complete
-- [ ] **Participate in the dependency resolution system** like CATs do
-- [ ] **Modify `handle_regular_transaction`** to lock keys when dependencies exist
-- [ ] **Enhance `update_to_final_status_and_update_counter`** to handle regular transaction lock release
-- [ ] **Create tests** for regular transaction dependencies
-- [ ] **Test mixed scenarios** (regular→CAT, CAT→regular, regular→regular) 
+**Key Changes Made**:
+- Renamed `key_locked_by_tx` to `key_last_locked_by_tx` to support onion layer model
+- Added `tx_locks_consumer` mapping to track dependency consumers
+- Updated `process_pending_transactions` to use consumer-based resolution
+- Added self-lock detection to prevent transactions from blocking themselves
+- All existing tests pass, confirming backward compatibility 

--- a/src/hyper_ig/node.rs
+++ b/src/hyper_ig/node.rs
@@ -1133,7 +1133,10 @@ impl HyperIGNode {
         {
             let mut state = self.state.lock().await;
             for key in &locked_keys {
-                state.key_last_locked_by_tx.remove(key);
+                // Only remove the key if the completed transaction is still the last locker
+                if state.key_last_locked_by_tx.get(key) == Some(&completed_tx_id) {
+                    state.key_last_locked_by_tx.remove(key);
+                }
             }
             // Clean up reverse index for O(1) key lookup
             state.tx_locks_keys.remove(&completed_tx_id);


### PR DESCRIPTION
## Summary

This PR introduces **full support for regular transaction dependencies**, enabling regular transactions to wait on other regular transactions or CAT transactions before execution.  
The dependency system now uses an **onion layer model**, allowing multiple layers of locking per key, with each transaction depending only on the immediate previous layer.

## Key Features
- **Regular transactions can depend on CATs or other regular transactions**
- **Onion layer dependency model** for sequential dependency resolution
- **Key locking for regular transactions** when dependencies exist
- **Automatic lock release and dependent notification** upon transaction completion
- **Support for timeouts** — pending regular transactions are released when a dependent CAT times out
- **Enhanced simulation plots** with block-based latency metrics

## Implementation Details
- Added `tx_locks_consumer` mapping to track dependency consumers
- Renamed `key_locked_by_tx` → `key_last_locked_by_tx` for onion model
- Updated `process_pending_transactions` to use consumer-based resolution
- Added self-lock detection to prevent deadlocks
- Introduced block-based latency conversion in plotting utilities
- Adjusted simulation configs for extended test sweeps

## Tests Added
- **`test_regular_tx_dependency_chain_resolution`** — verifies sequential resolution of regular transactions
- **`test_regular_tx_multiple_dependencies`** — ensures correct handling when regular TXs depend on multiple CATs
- **`test_regular_tx_released_on_cat_timeout`** — validates dependency release on CAT timeout
- Updated timing metrics tests to cover block-based latency

## Simulator & Config Changes
- Added plotting for:
  - `regular_tx_avg_latency_blocks`
  - `regular_tx_max_latency_blocks`
- Updated sweep configs for:
  - Smaller `target_tpb`
  - Increased simulation counts
  - Adjusted block intervals, ratios, lifetimes, and steps